### PR TITLE
Pin MinIO in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         ports:
           - 5672:5672
       minio:
-        image: bitnami/minio:latest
+        image: bitnami/minio:2025.4.22
         env:
           MINIO_ROOT_USER: minioAccessKey
           MINIO_ROOT_PASSWORD: minioSecretKey

--- a/.github/workflows/nightly_ci.yml
+++ b/.github/workflows/nightly_ci.yml
@@ -21,7 +21,7 @@ jobs:
         ports:
           - 5672:5672
       minio:
-        image: bitnami/minio:latest
+        image: bitnami/minio:2025.4.22
         env:
           MINIO_ROOT_USER: minioAccessKey
           MINIO_ROOT_PASSWORD: minioSecretKey


### PR DESCRIPTION
This PR pins the MinIO image used in CI to `bitnami/minio:2025.4.22`, as was done in the resonant cookiecutter upstream: https://github.com/kitware-resonant/cookiecutter-resonant/pull/334