### PR TITLE
Further refactor map source and layer handling

### DIFF
--- a/web/src/store/layer.ts
+++ b/web/src/store/layer.ts
@@ -35,7 +35,7 @@ export const useLayerStore = defineStore('layer', () => {
   function getMapLayersFromLayerObject(layer: Layer) {
     // Map layer format is <layerId>.<layerCopyId>.<frameId>.<type>.<typeId>,
     // where type is vector, raster, or 'bounds' (used for raster bounds)
-    return mapStore.getMap().getLayersOrder().filter((layerId) => layerId.startsWith(mapStore.uniqueLayerIdFromLayer(layer)));
+    return mapStore.getUserMapLayers().filter((layerId) => layerId.startsWith(mapStore.uniqueLayerIdFromLayer(layer)));
   }
 
   async function fetchAvailableLayer(layerId: number) {
@@ -175,31 +175,27 @@ export const useLayerStore = defineStore('layer', () => {
 
         // TODO: Move this conditional functionality into `addLayer`, and directly call addLayerFrameToMap there
         const sourceId = mapStore.sourceIdFromLayerFrame(layer, frame);
-        if (layer.visible && !map.getLayersOrder().some(
+        if (layer.visible && !mapStore.getUserMapLayers().some(
           (mapLayerId) => mapLayerId.includes(sourceId)
         ) && layer.current_frame_index === frame.index) {
           mapStore.addLayerFrameToMap(frame, sourceId, multiFrame);
         }
 
-        map.getLayersOrder().forEach((mapLayerId) => {
-          if (mapLayerId !== 'base-tiles') {
-            if (mapLayerId.includes(sourceId)) {
-              map.moveLayer(mapLayerId);  // handles reordering
-            }
+        mapStore.getUserMapLayers().forEach((mapLayerId) => {
+          if (mapLayerId.includes(sourceId)) {
+            map.moveLayer(mapLayerId);  // handles reordering
           }
         });
       })
       styleStore.updateLayerStyles(layer)
     })
     // hide any removed layers
-    map.getLayersOrder().forEach((mapLayerId) => {
-      if (mapLayerId !== 'base-tiles') {
-        const { layerId, layerCopyId } = mapStore.parseLayerString(mapLayerId);
-        if (!selectedLayers.value.some((l) => {
-          return l.id == layerId && l.copy_id == layerCopyId
-        })) {
-          map.setLayoutProperty(mapLayerId, "visibility", "none");
-        }
+    mapStore.getUserMapLayers().forEach((mapLayerId) => {
+      const { layerId, layerCopyId } = mapStore.parseLayerString(mapLayerId);
+      if (!selectedLayers.value.some((l) => {
+        return l.id == layerId && l.copy_id == layerCopyId
+      })) {
+        map.setLayoutProperty(mapLayerId, "visibility", "none");
       }
     });
   }

--- a/web/src/store/map.ts
+++ b/web/src/store/map.ts
@@ -156,14 +156,12 @@ export const useMapStore = defineStore('map', () => {
   // Update the base layer visibility
   watch(showMapBaseLayer, () => {
     const map = getMap();
-    map.getLayersOrder().forEach((id) => {
-      if (id === 'base-tiles') {
-        map.setLayoutProperty(
-          id,
-          "visibility",
-          showMapBaseLayer.value ? "visible" : "none"
-        );
-      }
+    getUserMapLayers().forEach((id) => {
+      map.setLayoutProperty(
+        id,
+        "visibility",
+        showMapBaseLayer.value ? "visible" : "none"
+      );
     });
   });
 
@@ -181,6 +179,10 @@ export const useMapStore = defineStore('map', () => {
   function getMapSources() {
     const map = getMap();
     return map.getLayersOrder().map((layerId) => map.getLayer(layerId)!.source);
+  }
+
+  function getUserMapLayers() {
+    return getMap().getLayersOrder().filter((id) => id !== 'base-tiles');
   }
 
   function getCurrentMapPosition() {
@@ -219,8 +221,7 @@ export const useMapStore = defineStore('map', () => {
   }
 
   function clearMapLayers() {
-    const userLayers = getMap().getLayersOrder().filter((id) => id !== 'base-tiles');
-    removeLayers(userLayers);
+    removeLayers(getUserMapLayers());
   }
 
   function removeLayers(layerIds: string[]) {
@@ -229,7 +230,7 @@ export const useMapStore = defineStore('map', () => {
     // Must collect all source Ids so they can be removed after all layers
     // have been removed, since multple layers may use the same source
     let sourceIdsToRemove = new Set<string>();
-    const layersToRemove = map.getLayersOrder().filter((id) => layerIds.includes(id));
+    const layersToRemove = getUserMapLayers().filter((id) => layerIds.includes(id));
     layersToRemove.forEach((id) => {
       sourceIdsToRemove.add(map.getLayer(id)!.source);
       map.removeLayer(id);
@@ -246,7 +247,7 @@ export const useMapStore = defineStore('map', () => {
  * layer to the map, or undefined if it's not on the map.
  */
   function getLatestLayerInstance(layer: Layer): LayerDescription | undefined {
-    const matchingLayers = getMap().getLayersOrder()
+    const matchingLayers = getUserMapLayers()
       .map((layerId) => parseLayerString(layerId))
       .filter((layerDesc) => layerDesc.layerId === layer.id);
 
@@ -468,5 +469,6 @@ export const useMapStore = defineStore('map', () => {
     sourceIdFromLayerFrame,
     uniqueLayerIdFromLayer,
     getLatestLayerInstance,
+    getUserMapLayers,
   }
 });

--- a/web/src/store/style.ts
+++ b/web/src/store/style.ts
@@ -306,23 +306,21 @@ export const useStyleStore = defineStore('style', () => {
         const frames = layerStore.layerFrames(layer)
         const currentFrame = frames.find((f) => f.index === layer.current_frame_index)
         if (!currentFrame) return
-        map.getLayersOrder().forEach((mapLayerId) => {
-            if (mapLayerId !== 'base-tiles') {
-                const { layerId, layerCopyId, frameId } = mapStore.parseLayerString(mapLayerId);
-                if (layerId === layer.id && layerCopyId === layer.copy_id) {
-                    if (frameId === currentFrame.id) {
-                        map.setLayoutProperty(mapLayerId, 'visibility', layer.visible ? 'visible' : 'none');
-                        const styleKey = `${layer.id}.${layer.copy_id}`
-                        const currentStyleSpec: StyleSpec = selectedLayerStyles.value[styleKey];
-                        setMapLayerStyle(
-                            mapLayerId,
-                            currentStyleSpec,
-                            currentFrame,
-                            currentFrame.vector,
-                        );
-                    } else {
-                        map.setLayoutProperty(mapLayerId, 'visibility', 'none');
-                    }
+        mapStore.getUserMapLayers().forEach((mapLayerId) => {
+            const { layerId, layerCopyId, frameId } = mapStore.parseLayerString(mapLayerId);
+            if (layerId === layer.id && layerCopyId === layer.copy_id) {
+                if (frameId === currentFrame.id) {
+                    map.setLayoutProperty(mapLayerId, 'visibility', layer.visible ? 'visible' : 'none');
+                    const styleKey = `${layer.id}.${layer.copy_id}`
+                    const currentStyleSpec: StyleSpec = selectedLayerStyles.value[styleKey];
+                    setMapLayerStyle(
+                        mapLayerId,
+                        currentStyleSpec,
+                        currentFrame,
+                        currentFrame.vector,
+                    );
+                } else {
+                    map.setLayoutProperty(mapLayerId, 'visibility', 'none');
                 }
             }
         });
@@ -418,7 +416,7 @@ export const useStyleStore = defineStore('style', () => {
         const activateColor = "#008837";
 
         const map = mapStore.getMap();
-        map.getLayersOrder().forEach((mapLayerId) => {
+        mapStore.getUserMapLayers().forEach((mapLayerId) => {
             if (mapLayerId.includes(".vector." + vectorId)) {
                 const { layerId, layerCopyId } = mapStore.parseLayerString(mapLayerId);
                 const currentStyle = selectedLayerStyles.value[`${layerId}.${layerCopyId}`];


### PR DESCRIPTION
Notable changes:

1. `mapSources` is no longer a variable in the map store, we just use a function to retrieve sources from the map directly (`getMapSources`)
2. The addition of the `getLatestLayerInstance` function
3. The addition of the `getUserMapLayers` function. This removes the need to filter out the `base-tiles` layer everywhere.