### PR TITLE
Move production extra to base requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ setup(
         'rasterio==1.3.10',
         'urllib3==1.26.15',
         'webcolors==24.6.0',
+        # Production only
+        'django-composed-configuration[prod]==0.25.0',
+        'django-s3-file-field[boto3]==1.0.1',
+        'gunicorn==22.0.0',
     ],
     extras_require={
         'dev': [
@@ -68,11 +72,6 @@ setup(
             'ipython==8.26.0',
             'tox==4.16.0',
             'pre-commit==4.0.1',
-        ],
-        'prod': [
-            'django-composed-configuration[prod]==0.25.0',
-            'django-s3-file-field[boto3]==1.0.1',
-            'gunicorn==22.0.0',
         ],
         'tasks': [
             'geoai-py==0.9.2',


### PR DESCRIPTION
Rather than expressing our production requirements with an extra, this PR moves those three libraries to the base requirements.