### PR TITLE
Slightly relax the package pinning for `gdal`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'django-large-image==0.10.2',
         'drf-yasg==1.21.7',
         # gdal 3.7 is the newest supported by Django: https://docs.djangoproject.com/en/5.0/ref/contrib/gis/install/geolibs/
-        'gdal==3.7.3',
+        'gdal==3.7.*',
         'large-image[gdal]==1.33.3',
         'large-image-converter==1.33.3',
         'matplotlib==3.9.2',  # for raster colormaps


### PR DESCRIPTION
This should allow the resolver to find wheels (not just sdists), which may be versioned like `3.7.3.1`.