### PR TITLE
Fix the syntax of `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
---find-links https://girder.github.io/large_image_wheels --editable .
+--find-links https://girder.github.io/large_image_wheels
+--editable .


### PR DESCRIPTION
Apparently the arguments need to be on separate lines. Tested and verified this locally.