### PR TITLE
adjust controls-bar offset for GeoInsight name

### DIFF
--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -124,7 +124,7 @@ function takeScreenshot(save: boolean) {
   padding: 3px 8px;
   position: absolute;
   top: 10px;
-  left: 180px;
+  left: 225px;
   opacity: 80%;
   background-color: rgb(var(--v-theme-surface));
   display: flex;


### PR DESCRIPTION
Minor fix I noticed when starting the compare PR.  I assume it was a result of the name change from UVDAT to GeoInsight.
It just caused the controls to overlap when the left sidebar was collasped:
<img width="1919" height="919" alt="image" src="https://github.com/user-attachments/assets/5bdbb94c-df32-46e7-abfa-33b860928cb3" />
Adjusted to be ~25px to the right, just like the expanded view:
<img width="1919" height="892" alt="image" src="https://github.com/user-attachments/assets/6c0aef3c-c4c2-4c6b-bc6b-9ac1a9295eb3" />
