### PR TITLE
supported reordering layers through vue-draggable

### DIFF
--- a/web/src/components/sidebars/LayersPanel.vue
+++ b/web/src/components/sidebars/LayersPanel.vue
@@ -12,12 +12,17 @@ const layerStore = useLayerStore();
 const mapStore = useMapStore()
 
 const searchText = ref<string | undefined>();
-const filteredLayers = computed(() => {
-    return layerStore.selectedLayers?.filter((layer: Layer) => {
-        return  !searchText.value ||
-        layer.name.toLowerCase().includes(searchText.value.toLowerCase())
-    })
-})
+const filteredLayers = computed({
+    get() {
+        return layerStore.selectedLayers?.filter((layer: Layer) => {
+            return  !searchText.value ||
+            layer.name.toLowerCase().includes(searchText.value.toLowerCase())
+        })
+    },
+    set(newValue) {
+        layerStore.selectedLayers = newValue;
+    }
+});
 const allLayersVisible = computed(() => layerStore.selectedLayers.every((l: Layer) => l.visible))
 const activeLayer = ref<Layer>();
 


### PR DESCRIPTION
This just updates the computed `filteredLayers` to have a `get` and `set`.  The `set` is needed because `filterLayers` is passed as a v-model to <draggable>.

Ultimately, it makes sure that the updated list can be resorted.