### PR TITLE
Move model-specific logic out of `GuardianPermission` class

### DIFF
--- a/geoinsight/core/models/chart.py
+++ b/geoinsight/core/models/chart.py
@@ -16,6 +16,10 @@ class Chart(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(project__in=projects)
+
     def spawn_conversion_task(
         self,
         conversion_options=None,

--- a/geoinsight/core/models/colormap.py
+++ b/geoinsight/core/models/colormap.py
@@ -37,6 +37,10 @@ class Colormap(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(models.Q(project__isnull=True) | models.Q(project__in=projects))
+
     def clean(self):
         if len(self.markers):
             validate(instance=self.markers, schema=MARKER_SCHEMA)

--- a/geoinsight/core/models/data.py
+++ b/geoinsight/core/models/data.py
@@ -23,6 +23,10 @@ class RasterData(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(dataset__project__in=projects)
+
     def get_image_data(self, resolution: float = 1.0):
         with tempfile.TemporaryDirectory() as tmp:
             raster_path = Path(tmp, 'raster')
@@ -47,6 +51,10 @@ class VectorData(models.Model):
 
     def __str__(self):
         return f'{self.name} ({self.id})'
+
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(dataset__project__in=projects)
 
     def write_geojson_data(self, content: str | dict):
         if isinstance(content, str):

--- a/geoinsight/core/models/dataset.py
+++ b/geoinsight/core/models/dataset.py
@@ -29,6 +29,11 @@ class Dataset(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        # Dataset permissions are not determined by Project permissions
+        return queryset
+
     def owner(self) -> User | None:
         users = typing.cast(
             list[User], list(get_users_with_perms(self, only_with_perms_in=['owner']))

--- a/geoinsight/core/models/file_item.py
+++ b/geoinsight/core/models/file_item.py
@@ -22,6 +22,10 @@ class FileItem(TimeStampedModel):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(dataset__project__in=projects)
+
 
 @receiver(models.signals.post_delete, sender=FileItem)
 def delete_content(sender, instance, **kwargs):

--- a/geoinsight/core/models/layer.py
+++ b/geoinsight/core/models/layer.py
@@ -19,6 +19,10 @@ class Layer(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(dataset__project__in=projects)
+
 
 class LayerFrame(models.Model):
     name = models.CharField(max_length=255, default='Layer Frame')
@@ -40,6 +44,10 @@ class LayerFrame(models.Model):
 
     def __str__(self):
         return f'{self.name} ({self.id})'
+
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(layer__dataset__project__in=projects)
 
     def get_data(self):
         if self.raster is not None:

--- a/geoinsight/core/models/networks.py
+++ b/geoinsight/core/models/networks.py
@@ -53,6 +53,10 @@ class Network(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(vector_data__dataset__project__in=projects)
+
     @property
     def dataset(self):
         return self.vector_data.dataset
@@ -109,6 +113,10 @@ class NetworkNode(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(network__dataset__project__in=projects)
+
     @property
     def dataset(self):
         return self.network.dataset
@@ -144,6 +152,10 @@ class NetworkEdge(models.Model):
 
     def __str__(self):
         return f'{self.name} ({self.id})'
+
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(network__dataset__project__in=projects)
 
     @property
     def dataset(self):

--- a/geoinsight/core/models/project.py
+++ b/geoinsight/core/models/project.py
@@ -18,6 +18,10 @@ class Project(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(id__in=projects.values_list('id', flat=True))
+
     def owner(self) -> User:
         users = typing.cast(
             list[User], list(get_users_with_perms(self, only_with_perms_in=['owner']))

--- a/geoinsight/core/models/regions.py
+++ b/geoinsight/core/models/regions.py
@@ -22,3 +22,7 @@ class Region(models.Model):
 
     def __str__(self):
         return f'{self.name} ({self.id})'
+
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(dataset__project__in=projects)

--- a/geoinsight/core/models/styles.py
+++ b/geoinsight/core/models/styles.py
@@ -29,6 +29,10 @@ class LayerStyle(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(layer__dataset__project__in=projects)
+
     def save_style_configs(self, style_spec):
         if style_spec is None:
             raise ValueError('style_spec must not be None.')

--- a/geoinsight/core/models/task_result.py
+++ b/geoinsight/core/models/task_result.py
@@ -26,6 +26,10 @@ class TaskResult(models.Model):
     def __str__(self):
         return f'{self.name} ({self.id})'
 
+    @classmethod
+    def filter_queryset_by_projects(cls, queryset, projects):
+        return queryset.filter(models.Q(project__isnull=True) | models.Q(project__in=projects))
+
     def write_error(self, err):
         if self.error is None:
             self.error = ''

--- a/geoinsight/core/rest/analytics.py
+++ b/geoinsight/core/rest/analytics.py
@@ -7,7 +7,6 @@ from geoinsight.core.models import Project, TaskResult
 from geoinsight.core.rest.access_control import (
     GuardianFilter,
     GuardianPermission,
-    filter_queryset_by_projects,
 )
 import geoinsight.core.rest.serializers as geoinsight_serializers
 from geoinsight.core.tasks.analytics import analysis_types
@@ -34,7 +33,7 @@ class AnalyticsViewSet(ReadOnlyModelViewSet):
             filtered_input_options = {}
             for k, v in instance.get_input_options().items():
                 if isinstance(v, QuerySet):
-                    filtered_queryset = filter_queryset_by_projects(
+                    filtered_queryset = v.model.filter_queryset_by_projects(
                         v, Project.objects.filter(id=project_id)
                     )
                     v = [dict(id=o.id, name=o.name) for o in filtered_queryset]

--- a/geoinsight/core/rest/dataset.py
+++ b/geoinsight/core/rest/dataset.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from geoinsight.core.models import Dataset, DatasetTag
-from geoinsight.core.rest.access_control import GuardianFilter, GuardianPermission
+from geoinsight.core.rest.access_control import DatasetGuardianPermission, GuardianFilter
 from geoinsight.core.rest.serializers import (
     DatasetSerializer,
     FileItemSerializer,
@@ -18,7 +18,7 @@ from geoinsight.core.rest.serializers import (
 class DatasetViewSet(ModelViewSet):
     queryset = Dataset.objects.all()
     serializer_class = DatasetSerializer
-    permission_classes = [GuardianPermission]
+    permission_classes = [DatasetGuardianPermission]
     filter_backends = [GuardianFilter]
     lookup_field = 'id'
 


### PR DESCRIPTION
This PR moves the model-specific logic out of `geoinsight/core/rest/access_control.py` and into the model definitions. Now each model that has a rest viewset should implement a `filter_queryset_by_projects` classmethod. The `GuardianPermission` and `GuardianFilter` classes leverage those classmethods to determine which objects a user has permission to interact with via the API. 

Datasets are an exception; their permission structure is separate from Projects, so a subclass `DatasetGuardianPermission` is implemented to specify Dataset permissions.

Resolves #208.
