### PR TITLE
Basemap menu adjustments

### DIFF
--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -213,10 +213,8 @@ watch(newBasemapStyleJSON, createNewBasemapPreview)
               <template v-slot:prepend>
                 <v-icon :icon="basemap.id === mapStore.currentBasemap?.id ? 'mdi-check' : 'none'" color="success"
                   class="pa-0"></v-icon>
-              </template>
-              <template v-slot:append>
-                <div v-if="basemap.id !== undefined" class="basemap-preview" :id="'basemap-preview-' + basemap.id">
-                </div>
+                <div v-if="basemap.id !== undefined" class="basemap-preview" :id="'basemap-preview-' + basemap.id" />
+                <div v-else style="width: 90px" />
               </template>
             </v-list-item>
           </v-list>
@@ -376,7 +374,7 @@ watch(newBasemapStyleJSON, createNewBasemapPreview)
 .basemap-preview {
   margin: 0px 10px;
   height: 50px;
-  width: 50px;
+  width: 70px;
 }
 
 #basemap-preview-new {


### PR DESCRIPTION
This PR makes some minor changes to the appearance of the basemap menu:

- For mini previews of existing basemaps, define the map position with the _bounds_ of the main map instead of the center and zoom. This eliminates the cropping effect due to the smaller map container.
- Move mini previews to the left of basemap names
- Modify the aspect ratio of mini previews (landscape rectangle instead of square)

<img width="1856" height="967" alt="image" src="https://github.com/user-attachments/assets/a038ebee-af9d-4f4f-b1ff-300e814cdb50" />
