### PR TITLE
fix: remove bounds vector layers with raster removal

### DIFF
--- a/web/src/store/map.ts
+++ b/web/src/store/map.ts
@@ -214,7 +214,7 @@ export const useMapStore = defineStore('map', () => {
   function getBaseLayerSourceIds() {
     return getMapSources()
       .filter((sourceId) => (
-        !sourceId || !(sourceId.includes('.vector.') || sourceId.includes('.raster.'))
+        !sourceId || !(sourceId.includes('.vector.') || sourceId.includes('.raster.') || sourceId.includes('.bounds.'))
       ));
   }
 
@@ -273,7 +273,15 @@ export const useMapStore = defineStore('map', () => {
     // Must collect all source Ids so they can be removed after all layers
     // have been removed, since multple layers may use the same source
     let sourceIdsToRemove = new Set<string>();
-    const layersToRemove = getUserMapLayers().filter((id) => layerIds.includes(id));
+    const updatedLayerIds: string[] = [];
+    layerIds.forEach((id) => {
+      // Rasters have implicit bounds layers that also need to be removed
+      if (id.includes('.raster.')) {
+        updatedLayerIds.push(id.replace('.raster.', '.bounds.'));
+      }
+      updatedLayerIds.push(id);
+    });
+    const layersToRemove = getUserMapLayers().filter((id) => updatedLayerIds.includes(id));
     layersToRemove.forEach((id) => {
       sourceIdsToRemove.add(map.getLayer(id)!.source);
       map.removeLayer(id);


### PR DESCRIPTION
resolves #253 

When rasters are added to the map they add another `.bounds.` layer that is a vector layer.  When removing the raster the layer still exists and the source isn't removed.  So when the user removes a raster layer and then adds it again there would be an error.

- Added `.bounds.` to the filter condition when `getBaseLayerSourceIds()` so that way the bounds layer isn't included in the list
- Updated `removeLayers()` so that if the removal is of type `.raster.` it will remove the same layerId with `.bounds.` and remove the same source