### PR TITLE
Run Semantic Release in an environment with uv and npm installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - name: Install npm
+        uses: actions/setup-node@v6
       - run: |
           npm ci
         working-directory: web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: write
 jobs:
-  tag-and-publish:
+  version-and-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -16,8 +16,10 @@ jobs:
           fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Python Semantic Release
-        id: release
-        uses: python-semantic-release/python-semantic-release@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install npm
+        uses: actions/setup-node@v6
+      - name: Run Semantic Release
+        run: |
+          uvx python-semantic-release version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Python CLI for Semantic Release provides the exact same functionality as the GitHub Action. Running on the CI host with the CLI allows us to have uv and npm available, so the Semantic Release build step to update lockfiles is able to run. The `python-semantic-release version` command already has all the defaults to run the build step, make a commit, push a tag, and push a release (the same steps as before).

This uses `uvx` to ephimerally install Semantic Release, instead of adding it as a proper dependency, since the version of Click required by Semantic Release is old and unnecessarily constrains other packages. Developers are not expected to run Semantic Release themselves locally.