### PR TITLE
Update default basemaps

### DIFF
--- a/geoinsight/core/models/basemaps.json
+++ b/geoinsight/core/models/basemaps.json
@@ -1,11 +1,49 @@
 [
     {
         "name": "Basic Light",
-        "style": "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+        "style": {
+            "version": 8,
+            "sources": {
+                "light": {
+                    "type": "raster",
+                    "tiles": [
+                        "https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+                    ],
+                    "tileSize": 256,
+                    "maxzoom": 19
+                }
+            },
+            "layers": [
+                {
+                    "id": "light",
+                    "type": "raster",
+                    "source": "light"
+                }
+            ]
+        }
     },
     {
         "name": "Basic Dark",
-        "style": "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+        "style": {
+            "version": 8,
+            "sources": {
+                "dark": {
+                    "type": "raster",
+                    "tiles": [
+                        "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
+                    ],
+                    "tileSize": 256,
+                    "maxzoom": 19
+                }
+            },
+            "layers": [
+                {
+                    "id": "dark",
+                    "type": "raster",
+                    "source": "dark"
+                }
+            ]
+        }
     },
     {
         "name": "NAIP Imagery",


### PR DESCRIPTION
Our deployed instance at https://www.geoinsight.kitware.com/ gets CORS errors when attempting to fetch the style and tiles of the default basemaps, which are hosted on [demo.kitware.com](demo.kitware.com). The default basemaps were not intended to be a sustainable service for large-scale deployments, so this PR updates the default basemaps to use publicly-available styles and tiles from [CartoCDN](https://basemaps.cartocdn.com/). 