### PR TITLE
Remove Git-LFS install from the development Dockerfile

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -11,13 +11,3 @@ ENV UV_PROJECT_ENVIRONMENT=/var/lib/venv \
   # The uv cache and environment are expected to be mounted on different volumes,
   # so hardlinks won't work
   UV_LINK_MODE=symlink
-
-RUN \
-  rm -f /etc/apt/apt.conf.d/docker-clean; \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN \
-  --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt update && \
-  apt-get --no-install-recommends install --yes \
-    git-lfs


### PR DESCRIPTION
This is no longer necessary, now that all dependencies are installed via PyPI.