### PR TITLE
Use the Allauth authentication backend to fix broken login

### DIFF
--- a/geoinsight/settings/base.py
+++ b/geoinsight/settings/base.py
@@ -119,10 +119,7 @@ LOGIN_REDIRECT_URL = '/'
 ACCOUNT_LOGOUT_REDIRECT_URL = '/'
 ACCOUNT_SIGNUP_FORM_CLASS = 'resonant_utils.allauth.FullNameSignupForm'
 
-AUTHENTICATION_BACKENDS = [
-    'django.contrib.auth.backends.ModelBackend',
-    'guardian.backends.ObjectPermissionBackend',
-]
+AUTHENTICATION_BACKENDS.append('guardian.backends.ObjectPermissionBackend')
 # django-guardian; raise PermissionDenied exception instead of redirecting to login page
 GUARDIAN_RAISE_403 = True
 # django-guardian; disable anonymous user permissions


### PR DESCRIPTION
The Resonant configuration uses the Django-Allauth authentication backend, as this is the only one which fully supports the other settings to use email-as-username on the login page.

Here, it looks like the attempt to use Django-Guardian also configured the `AUTHENTICATION_BACKENDS` setting to use the the Django authentication backend (`ModelBackend`). This works for the admin page (since the admin page technically only contains `username` and `password` fields), but fails on the Allauth login pages (since, as configured, they contain `email` and `password` fields).

This change preserves the Resonant-default authentication backend and just adds Django-Guardian.