### PR TITLE
Fix `boolean-default-value-positional-argument` errors

### DIFF
--- a/geoinsight/core/management/commands/ingest.py
+++ b/geoinsight/core/management/commands/ingest.py
@@ -98,7 +98,7 @@ class ChartItem(TypedDict, total=False):
     conversion_options: ConversionOptions
 
 
-def ingest_file(file_info, index=0, dataset=None, chart=None, replace=False, skip_cache=False):
+def ingest_file(file_info, *, index=0, dataset=None, chart=None, replace=False, skip_cache=False):
     file_path = file_info.get("path")
     file_name = file_info.get("name", file_path.split("/")[-1])
     file_url = file_info.get("url")
@@ -150,7 +150,7 @@ def ingest_file(file_info, index=0, dataset=None, chart=None, replace=False, ski
             new_file_item.file.save(file_path, ContentFile(f.read()))
 
 
-def ingest_projects(data: list[ProjectItem], replace=False) -> None:
+def ingest_projects(data: list[ProjectItem], *, replace=False) -> None:
     for project in data:
         click.echo(f"\t- {project['name']}")
         existing = Project.objects.filter(name=project["name"])
@@ -189,7 +189,7 @@ def ingest_projects(data: list[ProjectItem], replace=False) -> None:
         project_for_setting.datasets.set(Dataset.objects.filter(name__in=project["datasets"]))
 
 
-def ingest_charts(data: list[ChartItem], replace=False, skip_cache=False) -> None:
+def ingest_charts(data: list[ChartItem], *, replace=False, skip_cache=False) -> None:
     for chart in data:
         click.echo(f"\t- {chart['name']}")
         existing = Chart.objects.filter(name=chart["name"])
@@ -261,7 +261,7 @@ def default_conversion_process(dataset: Dataset, options: DatasetItem):
 
 
 def ingest_datasets(
-    data: list[DatasetItem], json_file_path: Path, replace=False, skip_cache=False
+    data: list[DatasetItem], json_file_path: Path, *, replace=False, skip_cache=False
 ) -> None:
     superuser = User.objects.filter(is_superuser=True).first()
     if superuser is None:
@@ -345,7 +345,7 @@ def ingest_datasets(
     default=False,
     help="Do not use cached downloaded files",
 )
-def ingest(file_path, replace, clear, skip_cache):
+def ingest(*, file_path, replace, clear, skip_cache):
     file_path = DATA_FOLDER / file_path
     if not file_path.exists():
         click.echo(f"File {file_path} does not exist.")

--- a/geoinsight/core/models/chart.py
+++ b/geoinsight/core/models/chart.py
@@ -24,6 +24,7 @@ class Chart(models.Model):
 
     def spawn_conversion_task(
         self,
+        *,
         conversion_options=None,
         asynchronous=True,
     ):

--- a/geoinsight/core/models/data.py
+++ b/geoinsight/core/models/data.py
@@ -73,7 +73,7 @@ class VectorData(models.Model):
         with self.geojson_data.open() as f:
             return json.load(f)
 
-    def get_summary(self, cache=True):
+    def get_summary(self, *, cache=True):
         if cache and self.summary:
             return self.summary
         # Limit number of unique values to return for non-numeric fields

--- a/geoinsight/core/models/dataset.py
+++ b/geoinsight/core/models/dataset.py
@@ -78,6 +78,7 @@ class Dataset(models.Model):
 
     def spawn_conversion_task(
         self,
+        *,
         layer_options=None,
         network_options=None,
         region_options=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,6 @@ ignore = [
   "BLE001", # blind-except
   "C901", # complex-structure
   "DJ001", # django-nullable-model-string-field
-  "FBT002", # boolean-default-value-positional-argument
   "PLC0415", # import-outside-top-level
   "PLR0912", # too-many-branches
   "PLR0913", # too-many-arguments


### PR DESCRIPTION
Note, the rule doesn't object to boolean arguments per se, tt just doesn't like them to be used positionally. This applies even if the boolean argument doesn't have a default value. However, making the argument keyword-only is usually a great solution.

I'd recommend reviewing: https://docs.astral.sh/ruff/rules/boolean-default-value-positional-argument/
