### PR TITLE
Use Celery's `Task.apply` when immediately invoking tasks

### DIFF
--- a/geoinsight/core/models/chart.py
+++ b/geoinsight/core/models/chart.py
@@ -29,10 +29,11 @@ class Chart(models.Model):
     ):
         from geoinsight.core.tasks.chart import convert_chart
 
+        convert_chart_signature = convert_chart.s(self.id, conversion_options)
         if asynchronous:
-            convert_chart.delay(self.id, conversion_options)
+            convert_chart_signature.delay()
         else:
-            convert_chart(self.id, conversion_options)
+            convert_chart_signature.apply()
 
     def new_line(self):
         # TODO: new line

--- a/geoinsight/core/models/dataset.py
+++ b/geoinsight/core/models/dataset.py
@@ -84,6 +84,13 @@ class Dataset(models.Model):
         region_options=None,
         asynchronous=True,
     ):
+        convert_dataset_signature = convert_dataset.s(
+            dataset_id=self.id,
+            layer_options=layer_options,
+            network_options=network_options,
+            region_options=region_options,
+        )
+
         if asynchronous:
             from geoinsight.core.models.task_result import TaskResult
 
@@ -98,12 +105,10 @@ class Dataset(models.Model):
                 },
                 status="Initializing task...",
             )
-            convert_dataset.delay(
-                self.id, layer_options, network_options, region_options, result.id
-            )
+            convert_dataset_signature.delay(result_id=result.id)
             return result
         else:
-            convert_dataset(self.id, layer_options, network_options, region_options)
+            convert_dataset_signature.apply()
             return None
 
     def get_size(self):


### PR DESCRIPTION
This ensures that the call is still processed by all of Celery's task machinery, improving parity with asynchronous invocation.