### PR TITLE
Misc client bug fixes

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,7 @@
         "chroma-js": "3.2.0",
         "dayjs": "1.11.20",
         "django-s3-file-field": "1.1.0",
-        "html2canvas": "1.4.1",
+        "html2canvas-pro": "^2.0.2",
         "json-editor-vue": "0.18.1",
         "lodash": "4.18.1",
         "maplibre-gl": "4.7.1",
@@ -6020,17 +6020,17 @@
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+    "node_modules/html2canvas-pro": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html2canvas-pro/-/html2canvas-pro-2.0.2.tgz",
+      "integrity": "sha512-9G/t0XgCZWonLwL0JwI7su6NdbOPUY7Ur4Ihpp8+XMaW9ibA2nDXF181Jr6tm94k8lX6sthpaXB3XqEnsMd5Cw==",
       "license": "MIT",
       "dependencies": {
         "css-line-break": "^2.1.0",
         "text-segmentation": "^1.0.3"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/https-proxy-agent": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
     "chroma-js": "3.2.0",
     "dayjs": "1.11.20",
     "django-s3-file-field": "1.1.0",
-    "html2canvas": "1.4.1",
+    "html2canvas-pro": "^2.0.2",
     "json-editor-vue": "0.18.1",
     "lodash": "4.18.1",
     "maplibre-gl": "4.7.1",

--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -25,11 +25,11 @@ import type {
 } from "@/types";
 
 export async function getUsers(): Promise<User[]> {
-  return (await apiClient.get("users/")).data.results;
+  return (await apiClient.get("users/")).data?.results;
 }
 
 export async function getBasemaps(): Promise<Basemap[]> {
-  return (await apiClient.get("basemaps/")).data.results;
+  return (await apiClient.get("basemaps/")).data?.results;
 }
 
 export async function createBasemap(basemap: Basemap): Promise<Basemap> {
@@ -37,7 +37,7 @@ export async function createBasemap(basemap: Basemap): Promise<Basemap> {
 }
 
 export async function getProjects(): Promise<Project[]> {
-  return (await apiClient.get("projects/")).data.results;
+  return (await apiClient.get("projects/")).data?.results;
 }
 
 export async function createProject(
@@ -75,7 +75,7 @@ export async function deleteProject(projectId: number): Promise<Project> {
 export async function getProjectDatasets(
   projectId: number,
 ): Promise<Dataset[]> {
-  return (await apiClient.get(`datasets/?project=${projectId}`)).data.results;
+  return (await apiClient.get(`datasets/?project=${projectId}`)).data?.results;
 }
 
 export async function getChart(chartId: number): Promise<Chart> {
@@ -87,7 +87,7 @@ export async function getChartFiles(chartId: number): Promise<FileItem[]> {
 }
 
 export async function getProjectCharts(projectId: number): Promise<Chart[]> {
-  return (await apiClient.get(`charts/?project=${projectId}`)).data.results;
+  return (await apiClient.get(`charts/?project=${projectId}`)).data?.results;
 }
 
 export async function getProjectAnalysisTypes(
@@ -97,7 +97,7 @@ export async function getProjectAnalysisTypes(
 }
 
 export async function getDatasets(): Promise<Dataset[]> {
-  return (await apiClient.get("datasets/")).data.results;
+  return (await apiClient.get("datasets/")).data?.results;
 }
 
 export async function getDataset(datasetId: number): Promise<Dataset> {
@@ -163,7 +163,7 @@ export async function getDatasetNetworks(
 export async function getProjectNetworks(
   projectId: number,
 ): Promise<Network[]> {
-  return (await apiClient.get(`networks/?project=${projectId}`)).data.results;
+  return (await apiClient.get(`networks/?project=${projectId}`)).data?.results;
 }
 
 export async function getNetwork(networkId: number): Promise<Network> {
@@ -267,7 +267,7 @@ export async function getVectorDataBounds(vectorId: number): Promise<number[]> {
 }
 
 export async function getLayerStyles(layerId: number): Promise<LayerStyle[]> {
-  return (await apiClient.get(`layer-styles/?layer=${layerId}`)).data.results;
+  return (await apiClient.get(`layer-styles/?layer=${layerId}`)).data?.results;
 }
 
 export async function createLayerStyle(data: LayerStyle): Promise<LayerStyle> {
@@ -288,7 +288,7 @@ export async function deleteLayerStyle(styleId: number): Promise<LayerStyle> {
 export async function getProjectColormaps(
   projectId: number,
 ): Promise<Colormap[]> {
-  return (await apiClient.get(`colormaps/?project=${projectId}`)).data.results;
+  return (await apiClient.get(`colormaps/?project=${projectId}`)).data?.results;
 }
 
 export async function createColormap(colormap: Colormap): Promise<Colormap> {

--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -25,11 +25,11 @@ import type {
 } from "@/types";
 
 export async function getUsers(): Promise<User[]> {
-  return (await apiClient.get("users/")).data?.results;
+  return (await apiClient.get("users/")).data.results;
 }
 
 export async function getBasemaps(): Promise<Basemap[]> {
-  return (await apiClient.get("basemaps/")).data?.results;
+  return (await apiClient.get("basemaps/")).data.results;
 }
 
 export async function createBasemap(basemap: Basemap): Promise<Basemap> {
@@ -37,7 +37,7 @@ export async function createBasemap(basemap: Basemap): Promise<Basemap> {
 }
 
 export async function getProjects(): Promise<Project[]> {
-  return (await apiClient.get("projects/")).data?.results;
+  return (await apiClient.get("projects/")).data.results;
 }
 
 export async function createProject(
@@ -75,7 +75,7 @@ export async function deleteProject(projectId: number): Promise<Project> {
 export async function getProjectDatasets(
   projectId: number,
 ): Promise<Dataset[]> {
-  return (await apiClient.get(`datasets/?project=${projectId}`)).data?.results;
+  return (await apiClient.get(`datasets/?project=${projectId}`)).data.results;
 }
 
 export async function getChart(chartId: number): Promise<Chart> {
@@ -87,7 +87,7 @@ export async function getChartFiles(chartId: number): Promise<FileItem[]> {
 }
 
 export async function getProjectCharts(projectId: number): Promise<Chart[]> {
-  return (await apiClient.get(`charts/?project=${projectId}`)).data?.results;
+  return (await apiClient.get(`charts/?project=${projectId}`)).data.results;
 }
 
 export async function getProjectAnalysisTypes(
@@ -97,7 +97,7 @@ export async function getProjectAnalysisTypes(
 }
 
 export async function getDatasets(): Promise<Dataset[]> {
-  return (await apiClient.get("datasets/")).data?.results;
+  return (await apiClient.get("datasets/")).data.results;
 }
 
 export async function getDataset(datasetId: number): Promise<Dataset> {
@@ -163,7 +163,7 @@ export async function getDatasetNetworks(
 export async function getProjectNetworks(
   projectId: number,
 ): Promise<Network[]> {
-  return (await apiClient.get(`networks/?project=${projectId}`)).data?.results;
+  return (await apiClient.get(`networks/?project=${projectId}`)).data.results;
 }
 
 export async function getNetwork(networkId: number): Promise<Network> {
@@ -267,7 +267,7 @@ export async function getVectorDataBounds(vectorId: number): Promise<number[]> {
 }
 
 export async function getLayerStyles(layerId: number): Promise<LayerStyle[]> {
-  return (await apiClient.get(`layer-styles/?layer=${layerId}`)).data?.results;
+  return (await apiClient.get(`layer-styles/?layer=${layerId}`)).data.results;
 }
 
 export async function createLayerStyle(data: LayerStyle): Promise<LayerStyle> {
@@ -288,7 +288,7 @@ export async function deleteLayerStyle(styleId: number): Promise<LayerStyle> {
 export async function getProjectColormaps(
   projectId: number,
 ): Promise<Colormap[]> {
-  return (await apiClient.get(`colormaps/?project=${projectId}`)).data?.results;
+  return (await apiClient.get(`colormaps/?project=${projectId}`)).data.results;
 }
 
 export async function createColormap(colormap: Colormap): Promise<Colormap> {

--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -153,13 +153,13 @@ async function createNewBasemapPreview() {
   newBasemapPreview.value.setCenter(center);
   newBasemapPreview.value.setZoom(zoom);
   if (newBasemapStyleJSON.value) {
-    if (typeof newBasemapStyleJSON.value == 'string') {
+    if (typeof newBasemapStyleJSON.value == "string") {
       try {
-        const response = await fetch(newBasemapStyleJSON.value)
-        const content = await response.json()
+        const response = await fetch(newBasemapStyleJSON.value);
+        const content = await response.json();
         jsonErrors.value = validateStyleMin(content);
       } catch {
-        jsonErrors.value = [{message: 'Invalid URL.'}]
+        jsonErrors.value = [{ message: "Invalid URL." }];
       }
     } else {
       jsonErrors.value = validateStyleMin(newBasemapStyleJSON.value);

--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -140,7 +140,7 @@ function setNewBasemapStyleFromTileURL() {
   }
 }
 
-function createNewBasemapPreview() {
+async function createNewBasemapPreview() {
   const map = mapStore.getMap();
   const center = map.getCenter();
   const zoom = map.getZoom();
@@ -153,7 +153,17 @@ function createNewBasemapPreview() {
   newBasemapPreview.value.setCenter(center);
   newBasemapPreview.value.setZoom(zoom);
   if (newBasemapStyleJSON.value) {
-    jsonErrors.value = validateStyleMin(newBasemapStyleJSON.value);
+    if (typeof newBasemapStyleJSON.value == 'string') {
+      try {
+        const response = await fetch(newBasemapStyleJSON.value)
+        const content = await response.json()
+        jsonErrors.value = validateStyleMin(content);
+      } catch {
+        jsonErrors.value = [{message: 'Invalid URL.'}]
+      }
+    } else {
+      jsonErrors.value = validateStyleMin(newBasemapStyleJSON.value);
+    }
     if (!jsonErrors.value?.length) {
       newBasemapPreview.value.setStyle(newBasemapStyleJSON.value);
       return;

--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
 import html2canvas from "html2canvas";
-import { Map } from "maplibre-gl";
+import { Map, type LngLatBoundsLike } from "maplibre-gl";
 
 import JsonEditorVue from "json-editor-vue";
 import "vanilla-jsoneditor/themes/jse-theme-dark.css";
@@ -81,7 +81,7 @@ const userHasEditPermission = computed(() => {
 function createBasemapPreviews() {
   if (basemapList.value) {
     const map = mapStore.getMap();
-    const bounds = map.getBounds();
+    const bounds = map.getBounds().toArray() as LngLatBoundsLike;
     mapStore.availableBasemaps.forEach((basemap) => {
       if (basemap.id === undefined || basemap.style === undefined) return;
       if (basemapPreviews.value[basemap.id]) {

--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
-import html2canvas from "html2canvas";
+import html2canvas from "html2canvas-pro";
 import { Map, type LngLatBoundsLike } from "maplibre-gl";
 
 import JsonEditorVue from "json-editor-vue";

--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { debounce } from "lodash";
 import { ref, watch, computed } from "vue";
 import html2canvas from "html2canvas-pro";
 import { Map, type LngLatBoundsLike } from "maplibre-gl";
@@ -298,8 +299,8 @@ function copyViewStateLink(viewState: ViewState) {
 
 watch(basemapList, createBasemapPreviews);
 watch(newBasemapTab, switchBasemapCreateTab);
-watch(newBasemapTileURL, setNewBasemapStyleFromTileURL);
-watch(newBasemapStyleJSON, createNewBasemapPreview);
+watch(newBasemapTileURL, debounce(setNewBasemapStyleFromTileURL, 1000));
+watch(newBasemapStyleJSON, debounce(createNewBasemapPreview, 1000));
 </script>
 
 <template>

--- a/web/src/components/map/ToggleCompareMap.vue
+++ b/web/src/components/map/ToggleCompareMap.vue
@@ -249,28 +249,30 @@ const swiperColor = computed(() => {
 
 onMounted(() => {
   if (!appStore.currentUser) {
-    const lightDefault = "https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
-    const darkDefault = "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
+    const lightDefault =
+      "https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
+    const darkDefault =
+      "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png";
     new Map({
       container: "mapContainer",
       attributionControl: false,
       style: {
-        layers: [{"id": "light", "type": "raster", "source": "light"}],
+        layers: [{ id: "light", type: "raster", source: "light" }],
         sources: {
           light: {
             type: "raster",
-            tiles: [appStore.theme === 'light' ? lightDefault: darkDefault],
+            tiles: [appStore.theme === "light" ? lightDefault : darkDefault],
             maxzoom: 19,
-            tileSize: 256
-          }
+            tileSize: 256,
+          },
         },
-        version: 8
+        version: 8,
       },
       center: [0, 0],
       zoom: 1, // Initial zoom level
     });
   }
-})
+});
 </script>
 
 <template>

--- a/web/src/components/map/ToggleCompareMap.vue
+++ b/web/src/components/map/ToggleCompareMap.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { useAppStore, useLayerStore, useMapStore } from "@/store";
 import { useMapCompareStore } from "@/store/compare";
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import type { Ref } from "vue";
 import { ToggleCompare } from "vue-maplibre-compare";
 import { oauthClient } from "@/api/auth";
 import "vue-maplibre-compare/dist/vue-maplibre-compare.css";
 import { addProtocol, AttributionControl, Popup } from "maplibre-gl";
-import type { StyleSpecification, Map } from "maplibre-gl";
+import { type StyleSpecification, Map } from "maplibre-gl";
 import { useTheme } from "vuetify";
 import { Protocol } from "pmtiles";
 import { storeToRefs } from "pinia";
@@ -246,6 +246,31 @@ const swiperColor = computed(() => {
     arrow: theme.global.current.value.colors["button-text"] as string,
   };
 });
+
+onMounted(() => {
+  if (!appStore.currentUser) {
+    const lightDefault = "https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
+    const darkDefault = "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
+    new Map({
+      container: "mapContainer",
+      attributionControl: false,
+      style: {
+        layers: [{"id": "light", "type": "raster", "source": "light"}],
+        sources: {
+          light: {
+            type: "raster",
+            tiles: [appStore.theme === 'light' ? lightDefault: darkDefault],
+            maxzoom: 19,
+            tileSize: 256
+          }
+        },
+        version: 8
+      },
+      center: [0, 0],
+      zoom: 1, // Initial zoom level
+    });
+  }
+})
 </script>
 
 <template>
@@ -288,6 +313,7 @@ const swiperColor = computed(() => {
       <MapTooltip compare-map />
     </div>
   </div>
+  <div v-else id="mapContainer" class="map"></div>
 </template>
 
 <style scoped>

--- a/web/src/components/map/ToggleCompareMap.vue
+++ b/web/src/components/map/ToggleCompareMap.vue
@@ -249,7 +249,7 @@ const swiperColor = computed(() => {
 </script>
 
 <template>
-  <div>
+  <div v-if="appStore.currentUser">
     <ToggleCompare
       :map-style-a="mapStyleA"
       :map-style-b="mapBStyle"

--- a/web/src/components/projects/ProjectConfig.vue
+++ b/web/src/components/projects/ProjectConfig.vue
@@ -574,7 +574,7 @@ watch(
 <style>
 .project-row {
   display: flex;
-  margin: 0px 8px;
+  margin: 8px;
   align-items: center;
   justify-content: space-between;
 }

--- a/web/src/components/sidebars/SideBars.vue
+++ b/web/src/components/sidebars/SideBars.vue
@@ -189,24 +189,18 @@ function togglePanelVisibility(id: string) {
               v-tooltip="'Panel Visibility'"
             ></v-icon>
           </template>
-          <v-list
-            :items="panelStore.panelArrangement.filter((p) => p.closeable)"
-            item-title="label"
-            item-value="id"
-            selectable
-            :selected="panelStore.panelArrangement.filter((p) => p.visible)"
-            @click:select="(item) => togglePanelVisibility(item.id as string)"
-            select-strategy="leaf"
-            return-object
-          >
-            <template v-slot:prepend="{ item, isSelected }">
-              <v-list-item-action start>
-                <v-checkbox-btn
-                  :model-value="isSelected"
-                  @change="togglePanelVisibility(item.id)"
-                ></v-checkbox-btn>
-              </v-list-item-action>
-            </template>
+          <v-list>
+            <v-list-item
+              v-for="item in panelStore.panelArrangement.filter(
+                (p) => p.closeable,
+              )"
+              @click="togglePanelVisibility(item.id)"
+            >
+              <v-checkbox-btn
+                :model-value="item.visible"
+                :label="item.label"
+              ></v-checkbox-btn>
+            </v-list-item>
           </v-list>
         </v-menu>
       </div>
@@ -306,5 +300,9 @@ function togglePanelVisibility(id: string) {
 
 .v-text-field {
   background-color: rgb(var(--v-theme-background));
+}
+
+.v-checkbox-btn .v-label {
+  margin-left: 5px;
 }
 </style>

--- a/web/src/components/sidebars/SideBars.vue
+++ b/web/src/components/sidebars/SideBars.vue
@@ -304,14 +304,6 @@ function togglePanelVisibility(id: string) {
   max-height: calc(100% - 100px);
 }
 
-.v-icon {
-  color: rgb(var(--v-theme-secondary-text)) !important;
-}
-
-.v-btn.bg-primary .v-icon {
-  color: rgb(var(--v-theme-button-text)) !important;
-}
-
 .v-text-field {
   background-color: rgb(var(--v-theme-background));
 }


### PR DESCRIPTION
This PR addresses various client bugs (some of which were caught by Sentry in production, some of which I found during the process).

Fixed Bugs
- Sentry caught this error when a request was unsuccessful: "Cannot read properties of undefined (reading 'results')". This can be solved with the "?" optional chaining operator wherever we access `.data.results` in `rest.ts` 
- The previews in the basemap options menu were broken due to the format of the bounds value. I don't know what changed to break this since I implemented it, but converting the format of the bounds fixed it.
- The screenshot feature was broken, raising the following error: "Unsupported color format color()". I swapped out `html2canvas` for [`html2canvas-pro`](https://www.npmjs.com/package/html2canvas-pro), which is a fork of the original with advanced color support. Again, I don't know what changed since I implemented screenshots, but the dependency swap fixes it.
- In the basemap creation dialog on the "MapLibre Style JSON" tab, the instructions state that you can paste JSON or you can specify a URL. However, the validation was broken if you pasted a URL; it tried to validate that string instead of the content at the url. I added a fetch statement wrapped in a try-except to handle this.

Other Improvements
- I fixed a few styling things that I noticed: some icons lacked colors and the spacing was too compact around the project config section of the left sidebar
- The menu to toggle the visibility of panels was a bit frustrating; you could click the name of a panel and it would animate like the click did something, but the toggle would only apply if you clicked directly on the checkbox. I fixed this so that clicking anywhere on the list item would apply the toggle. 