### PR TITLE
Don't raise "Clicked node is undefined" error

### DIFF
--- a/web/src/components/map/MapTooltip.vue
+++ b/web/src/components/map/MapTooltip.vue
@@ -140,18 +140,17 @@ watch(clickedFeature, () => {
 });
 
 async function updateClickedFeatureIsDeactivatedNode() {
-  if (clickedFeature.value === undefined) {
-    throw new Error("Clicked node is undefined!");
-  }
-  const feature = clickedFeature.value.feature;
-  const sourceId = feature.source;
-  const nodeId = clickedFeature.value.feature.properties.node_id;
-  const { dataset } = layerStore.getDBObjectsForSourceID(sourceId);
-  if (dataset) {
-    const active = await networkStore.isNodeActive(nodeId, dataset);
-    clickedFeatureIsDeactivatedNode.value = !active;
-  } else {
-    clickedFeatureIsDeactivatedNode.value = false;
+  if (clickedFeature.value) {
+    const feature = clickedFeature.value.feature;
+    const sourceId = feature.source;
+    const nodeId = clickedFeature.value.feature.properties.node_id;
+    const { dataset } = layerStore.getDBObjectsForSourceID(sourceId);
+    if (dataset) {
+      const active = await networkStore.isNodeActive(nodeId, dataset);
+      clickedFeatureIsDeactivatedNode.value = !active;
+    } else {
+      clickedFeatureIsDeactivatedNode.value = false;
+    }
   }
 }
 


### PR DESCRIPTION
This PR removes a statement in `MapTooltip.vue` where an error is raised due to the clicked feature being undefined, but there are circumstances in which we expect this to be the case, so this error should not be raised. 

[This Sentry error](https://kitware-data.sentry.io/issues/7366244049/events/37f5075847c74dcf81e7b094046a97e9/) is an example. The following steps reproduce this case:
- Add the MBTA Rapid Transit layer to the map
- Click on any node to view the tooltip
- Without dismissing the tooltip, toggle the visibility of the layer (the error will occur on master and will not occur on this branch)

With this change, `updateClickedFeatureIsDeactivatedNode` is a no-op when `clickedFeature.value` is undefined. When the layer containing the clicked feature disappears, the tooltip will disappear, too. It will only reappear when the next feature is clicked.