### PR TITLE
Use the standard prefix `VITE_` for Vite env vars

### DIFF
--- a/dev/.env.docker-compose
+++ b/dev/.env.docker-compose
@@ -11,3 +11,5 @@ DJANGO_REDIS_URL=redis://redis:6379
 # access from non-internal addresses.
 DJANGO_INTERNAL_IPS=0.0.0.0/0
 DJANGO_UVDAT_WEB_URL=http://localhost:8080/
+
+VITE_API_ROOT=http://localhost:8000/

--- a/dev/.env.docker-compose-native
+++ b/dev/.env.docker-compose-native
@@ -4,3 +4,5 @@ DJANGO_CELERY_BROKER_URL=amqp://localhost:5672/
 DJANGO_MINIO_STORAGE_URL=http://minioAccessKey:minioSecretKey@localhost:9000/django-storage
 DJANGO_REDIS_URL=redis://localhost:6379
 DJANGO_UVDAT_WEB_URL=http://localhost:8080/
+
+VITE_API_ROOT=http://localhost:8000/

--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -1,6 +1,6 @@
 locals {
   www_env_vars = {
-    VITE_APP_API_ROOT = "https://${module.django.fqdn}/"
+    VITE_API_ROOT = "https://${module.django.fqdn}/"
   }
 }
 
@@ -37,7 +37,7 @@ resource "cloudflare_pages_project" "www" {
       environment_variables = merge(
         local.www_env_vars,
         {
-          VITE_APP_SENTRY_DSN = "https://648b9234b2fc2df0dd59192ddb0111f7@o267860.ingest.us.sentry.io/4511108704501760"
+          VITE_SENTRY_DSN = "https://648b9234b2fc2df0dd59192ddb0111f7@o267860.ingest.us.sentry.io/4511108704501760"
         },
       )
       secrets = {

--- a/web/.env.development
+++ b/web/.env.development
@@ -1,1 +1,0 @@
-VITE_APP_API_ROOT=http://localhost:8000/

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -5,10 +5,10 @@ interface ViteTypeOptions {
 }
 
 interface ImportMetaEnv {
-  readonly VITE_APP_API_ROOT: string;
-  readonly VITE_APP_VERSION: string;
+  readonly VITE_API_ROOT: string;
+  readonly VITE_VERSION: string;
   // This is not set in development
-  readonly VITE_APP_SENTRY_DSN?: string;
+  readonly VITE_SENTRY_DSN?: string;
 }
 
 interface ImportMeta {

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -11,13 +11,13 @@ declare module "axios" {
 
 const OAUTH2_CLIENT_ID = "cBmD6D6F2YAmMWHNQZFPUr4OpaXVpW5w4Thod6Kj";
 
-export const baseURL = `${import.meta.env.VITE_APP_API_ROOT}api/v1/`;
+export const baseURL = `${import.meta.env.VITE_API_ROOT}api/v1/`;
 
 export const apiClient = axios.create({
   baseURL,
 });
 export const oauthClient = new OauthClient(
-  new URL(`${import.meta.env.VITE_APP_API_ROOT}oauth/`),
+  new URL(`${import.meta.env.VITE_API_ROOT}oauth/`),
   OAUTH2_CLIENT_ID,
   { redirectUrl: new URL(window.location.origin) },
 );
@@ -81,5 +81,5 @@ apiClient.interceptors.response.use(
 
 export const logout = async () => {
   await oauthClient.logout();
-  window.location.href = `${import.meta.env.VITE_APP_API_ROOT}accounts/logout/`;
+  window.location.href = `${import.meta.env.VITE_API_ROOT}accounts/logout/`;
 };

--- a/web/src/components/map/LegacyMap.vue
+++ b/web/src/components/map/LegacyMap.vue
@@ -61,7 +61,7 @@ function createMap() {
     // transformRequest adds auth headers to tile requests
     transformRequest: (url) => {
       let headers = {};
-      if (url.includes(import.meta.env.VITE_APP_API_ROOT)) {
+      if (url.includes(import.meta.env.VITE_API_ROOT)) {
         headers = oauthClient?.authHeaders;
       }
       return { url, headers };

--- a/web/src/components/map/ToggleCompareMap.vue
+++ b/web/src/components/map/ToggleCompareMap.vue
@@ -159,7 +159,7 @@ watch(
 
 const transformRequest = (url: string) => {
   // Only add auth headers to our own tile requests
-  if (url.includes(import.meta.env.VITE_APP_API_ROOT)) {
+  if (url.includes(import.meta.env.VITE_API_ROOT)) {
     return {
       url,
       headers: oauthClient?.authHeaders,

--- a/web/src/components/sidebars/SideBars.vue
+++ b/web/src/components/sidebars/SideBars.vue
@@ -19,7 +19,7 @@ const appStore = useAppStore();
 const panelStore = usePanelStore();
 const projectStore = useProjectStore();
 
-const version = import.meta.env.VITE_APP_VERSION;
+const version = import.meta.env.VITE_VERSION;
 const copied: Ref<string | undefined> = ref();
 
 function copyToClipboard(content: string) {

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -49,7 +49,7 @@ app.use(router);
 Sentry.init({
   app,
   // This is only defined in the release build environment
-  dsn: import.meta.env.VITE_APP_SENTRY_DSN,
+  dsn: import.meta.env.VITE_SENTRY_DSN,
   sendDefaultPii: true,
   integrations: [Sentry.browserTracingIntegration({ router })],
 });

--- a/web/src/store/analysis.ts
+++ b/web/src/store/analysis.ts
@@ -45,7 +45,7 @@ export const useAnalysisStore = defineStore("analysis", () => {
   function createWebSocket() {
     if (ws.value) ws.value.close();
     if (projectStore.currentProject) {
-      const urlBase = `${import.meta.env.VITE_APP_API_ROOT}ws/`;
+      const urlBase = `${import.meta.env.VITE_API_ROOT}ws/`;
       const url = `${urlBase}analytics/project/${projectStore.currentProject.id}/results/`;
       ws.value = new WebSocket(url);
       ws.value.onmessage = (event: any) => {

--- a/web/src/store/conversion.ts
+++ b/web/src/store/conversion.ts
@@ -3,7 +3,7 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { useProjectStore } from "./project";
 
-const url = `${import.meta.env.VITE_APP_API_ROOT}ws/conversion/`;
+const url = `${import.meta.env.VITE_API_ROOT}ws/conversion/`;
 
 export const useConversionStore = defineStore("conversion", () => {
   const projectStore = useProjectStore();

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,7 +10,14 @@ import { fileURLToPath, URL } from "node:url";
 
 import packageJson from "./package.json";
 
-process.env.VITE_APP_VERSION = packageJson.version;
+// Build sanity check, to ensure environment is defined;
+// this will not load from .env files (unless we used a different Vite syntax),
+// but we set VITE_API_ROOT at the process level.
+if (!process.env.VITE_API_ROOT) {
+  throw new Error("VITE_API_ROOT must be defined.");
+}
+
+process.env.VITE_VERSION = packageJson.version;
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
`VUE_APP_` was used in Vue CLI, but [Vite uses only the prefix `VITE_`](https://vite.dev/guide/env-and-mode#env-variables). The extra `APP_` is pointless.