### PR TITLE
Set Redis max memory policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
 
   redis:
     image: redis:alpine
+    command: ["redis-server", "--maxmemory", "4096MB", "--maxmemory-policy", "allkeys-lru"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       start_period: 30s

--- a/terraform/django.tf
+++ b/terraform/django.tf
@@ -40,6 +40,10 @@ module "django" {
 resource "heroku_addon" "redis" {
   app_id = module.django.heroku_app_id
   plan   = "heroku-redis:mini"
+
+  config = {
+    maxmemory_policy = "allkeys-lru"
+  }
 }
 
 output "dns_nameservers" {


### PR DESCRIPTION
Resolves #398 

This PR changes the command for the Redis container in development to the following:
```
["redis-server", "--maxmemory", "4096MB", "--maxmemory-policy", "allkeys-lru"]
```

For production, we can't set the max memory size of the Heroku Redis add-on without upgrading the plan (we currently use the mini plan), but we can set the max memory policy to `allkeys-lru`.