### PR TITLE
Revert to using django cache for large image

### DIFF
--- a/uvdat/settings/base.py
+++ b/uvdat/settings/base.py
@@ -157,10 +157,6 @@ CHANNEL_LAYERS: dict[str, dict[str, Any]] = {
     }
 }
 
-# Large image cache with Redis
-LARGE_IMAGE_CACHE_BACKEND = "redis"
-LARGE_IMAGE_CACHE_REDIS_URL = env.url("DJANGO_REDIS_URL").geturl()
-
 UVDAT_WEB_URL: str = env.url("DJANGO_UVDAT_WEB_URL").geturl()
 UVDAT_ENABLE_FLOOD_SIMULATION: bool = env.bool("DJANGO_UVDAT_ENABLE_FLOOD_SIMULATION", default=True)
 UVDAT_ENABLE_FLOOD_NETWORK_FAILURE: bool = env.bool(


### PR DESCRIPTION
After discussion on #400, we decided to make an upstream change to large_image (tracked with [this issue](https://github.com/girder/large_image/issues/2081)). While waiting for the upstream change, this PR reverts to using django for the large image cache.
