### PR TITLE
Redis "volatile-lru" cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
 
   redis:
     image: redis:alpine
+    command: ["redis-server", "--maxmemory", "4096MB", "--maxmemory-policy", "volatile-lru"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       start_period: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
 
   redis:
     image: redis:alpine
-    command: ["redis-server", "--maxmemory", "4096MB", "--maxmemory-policy", "volatile-lru"]
+    command: ["redis-server", "--maxmemory", "4GB", "--maxmemory-policy", "volatile-lru"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       start_period: 30s

--- a/terraform/django.tf
+++ b/terraform/django.tf
@@ -45,6 +45,10 @@ module "django" {
 resource "heroku_addon" "redis" {
   app_id = module.django.heroku_app_id
   plan   = "heroku-redis:mini"
+
+  config = {
+    maxmemory_policy = "volatile-lru"
+  }
 }
 
 output "dns_nameservers" {

--- a/uvdat/settings/base.py
+++ b/uvdat/settings/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import logging
 from pathlib import Path
 from typing import Any
@@ -155,6 +156,23 @@ CHANNEL_LAYERS: dict[str, dict[str, Any]] = {
             ]
         },
     }
+}
+
+# Large image cache with Redis
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+    "tiles": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": env.url("DJANGO_REDIS_URL").geturl(),
+        "OPTIONS": {
+            # Use database /2 for the tile cache,
+            # in case other services use /0 in the future
+            "db": "2",
+        },
+        "TIMEOUT": int(datetime.timedelta(weeks=4).total_seconds()),
+    },
 }
 
 UVDAT_WEB_URL: str = env.url("DJANGO_UVDAT_WEB_URL").geturl()

--- a/uvdat/settings/base.py
+++ b/uvdat/settings/base.py
@@ -142,13 +142,14 @@ CORS_ALLOWED_ORIGIN_REGEXES: list[str] = env.list(
 )
 
 # django-channels with Redis
+_redis_url = env.url("DJANGO_REDIS_URL").geturl()
 CHANNEL_LAYERS: dict[str, dict[str, Any]] = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [
                 {
-                    "address": env.url("DJANGO_REDIS_URL").geturl(),
+                    "address": _redis_url,
                     # Use database /1 for Channels backend,
                     # in case other services use /0 in the future
                     "db": 1,
@@ -165,12 +166,13 @@ CACHES = {
     },
     "tiles": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": env.url("DJANGO_REDIS_URL").geturl(),
+        "LOCATION": _redis_url,
         "OPTIONS": {
             # Use database /2 for the tile cache,
             # in case other services use /0 in the future
             "db": "2",
         },
+        # TTL of 4 weeks (an arbitrarily long time)
         "TIMEOUT": int(datetime.timedelta(weeks=4).total_seconds()),
     },
 }


### PR DESCRIPTION
This PR sets the large image tile cache to use redis with the "volatile-lru" max memory policy. Cached tiles have a TTL of 4 weeks.

See [x](https://github.com/OpenGeoscience/geodatalytics/pull/400) and [x](https://github.com/girder/large_image/pull/2092). Resolves #398.