### PR TITLE
Fix validation logic for dataset upload form

### DIFF
--- a/web/src/components/projects/DatasetUpload.vue
+++ b/web/src/components/projects/DatasetUpload.vue
@@ -75,7 +75,7 @@ const valid = computed(() => {
       return (
         l.name &&
         l.files.length &&
-        fileUploadRules.every((rule) => rule(l.files) === undefined) &&
+        fileUploadRules.every((rule) => rule(l.files) === true) &&
         (l.frame_method === "single" || l.frame_property)
       );
     })


### PR DESCRIPTION
While writing the documentation for dataset upload, I found a bug in the validation logic. The max upload size validation rule never returns `undefined`; it returns a string error message or `true`. In the definition of the computed `valid` variable, we had checked for `undefined` values. This PR changes that logic to check whether an error message string was returned.