### PR TITLE
Fix screenshot map-only behavior

### DIFF
--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -198,7 +198,7 @@ async function fitMap() {
   loadingBounds.value = false;
 }
 
-async function takeScreenshot() {
+async function takeScreenshot(showSidebars: boolean) {
   copyMenuShown.value = false;
   const screenshotTarget = document.getElementById("app");
   if (screenshotTarget) {
@@ -207,7 +207,7 @@ async function takeScreenshot() {
         return (
           element.id === "controls-bar" ||
           element.classList.contains("control-menu") ||
-          (mapOnly.value && element.classList.contains("v-navigation-drawer"))
+          (!showSidebars && element.classList.contains("v-navigation-drawer"))
         );
       },
     });
@@ -219,7 +219,7 @@ async function takeScreenshot() {
 }
 
 async function copyScreenshot() {
-  const blob = await takeScreenshot();
+  const blob = await takeScreenshot(!mapOnly.value);
   if (blob) {
     const clipboardItem = new ClipboardItem({ "image/png": blob });
     navigator.clipboard.write([clipboardItem]);
@@ -228,7 +228,7 @@ async function copyScreenshot() {
 }
 
 async function saveScreenshot() {
-  const blob = await takeScreenshot();
+  const blob = await takeScreenshot(!mapOnly.value);
   if (blob) {
     const link = document.createElement("a");
     link.href = URL.createObjectURL(blob);
@@ -251,7 +251,7 @@ function animateCameraFlash() {
 }
 
 function showViewStateDialog() {
-  takeScreenshot().then((blob) => {
+  takeScreenshot(true).then((blob) => {
     newViewStateThumbnail.value = blob;
   });
   showViewStateCreation.value = true;


### PR DESCRIPTION
As I was writing the documentation for the controls bar, I found this bug. The `takeScreenshot` function is used for the screenshot menu AND for creating the thumbnail for a new saved view. That function used `mapOnly` to determine whether to include sidebar elements in the screenshot, but `mapOnly` should only apply to the screenshots menu. If `mapOnly` was checked in the screenshot menu, the thumbnail for a new saved view would not include the sidebars. This PR adjusts that behavior such that sidebars are always included in new view thumbnails.