### PR TITLE
Fix Legend Panel Bug & Style

### DIFF
--- a/web/src/components/sidebars/ColormapPreview.vue
+++ b/web/src/components/sidebars/ColormapPreview.vue
@@ -67,9 +67,9 @@ watch(
 
 <template>
   <div class="d-flex" style="column-gap: 5px; width: 100%">
-    <span v-if="props.range">{{ props.range[0] }}</span>
+    <span v-if="props.range">{{ props.range[0]?.toPrecision(3) }}</span>
     <canvas ref="canvas" class="colormap-canvas"></canvas>
-    <span v-if="props.range">{{ props.range[1] }}</span>
+    <span v-if="props.range">{{ props.range[1]?.toPrecision(3) }}</span>
   </div>
 </template>
 

--- a/web/src/components/sidebars/LayersPanel.vue
+++ b/web/src/components/sidebars/LayersPanel.vue
@@ -59,13 +59,6 @@ function removeLayers(layers: Layer[]) {
   mapStore.removeLayers(layerIds);
 }
 
-function setVisibility(layers: Layer[], visible = true) {
-  layerStore.selectedLayers = layerStore.selectedLayers.map((layer: Layer) => {
-    if (layers.includes(layer)) layer.visible = visible;
-    return layer;
-  });
-}
-
 const debouncedUpdateFrame = debounce((layer: Layer, value: number) => {
   layerStore.selectedLayers = layerStore.selectedLayers.map((l: Layer) => {
     if (l.id === layer.id && l.copy_id === layer.copy_id) {
@@ -118,7 +111,12 @@ function setLayerActive(layer: Layer, active: boolean) {
           v-if="!isComparing"
           :model-value="allFilteredLayersVisible"
           style="display: inline"
-          @click="setVisibility(filteredLayers, !allFilteredLayersVisible)"
+          @click="
+            layerStore.setLayerVisibility(
+              filteredLayers,
+              !allFilteredLayersVisible,
+            )
+          "
         />
         <span v-if="isComparing">
           <v-checkbox-btn
@@ -160,7 +158,13 @@ function setLayerActive(layer: Layer, active: boolean) {
                     v-if="!isComparing"
                     :model-value="element.visible"
                     style="display: inline"
-                    @click="() => setVisibility([element], !element.visible)"
+                    @click="
+                      () =>
+                        layerStore.setLayerVisibility(
+                          [element],
+                          !element.visible,
+                        )
+                    "
                   />
                   <span v-if="isComparing">
                     <v-checkbox-btn

--- a/web/src/components/sidebars/LegendPanel.vue
+++ b/web/src/components/sidebars/LegendPanel.vue
@@ -92,13 +92,6 @@ function getColormapPreviews(layer: Layer) {
   });
 }
 
-function setVisibility(layer: Layer, visible = true) {
-  layerStore.selectedLayers = layerStore.selectedLayers.map((l: Layer) => {
-    if (l.id == layer.id) l.visible = visible;
-    return l;
-  });
-}
-
 function getColorPropsCoverage(layer: Layer) {
   const frame_coverages = layerStore
     .layerFrames(layer)
@@ -126,7 +119,7 @@ function getColorPropsCoverage(layer: Layer) {
           <v-icon
             :icon="layer.visible ? 'mdi-eye-outline' : 'mdi-eye-off-outline'"
             class=""
-            @click="setVisibility(layer, !layer.visible)"
+            @click="layerStore.setLayerVisibility([layer], !layer.visible)"
           />
           {{ layer.name }}
           <div

--- a/web/src/components/sidebars/LegendPanel.vue
+++ b/web/src/components/sidebars/LegendPanel.vue
@@ -127,7 +127,10 @@ function getColorPropsCoverage(layer: Layer) {
             :key="colormap_preview.name"
             class="ml-6"
           >
-            <div v-if="getColormapPreviews(layer).length > 1">
+            <div
+              v-if="getColormapPreviews(layer).length > 1"
+              style="font-weight: bold"
+            >
               {{ colormap_preview.name }}
             </div>
             <span

--- a/web/src/store/layer.ts
+++ b/web/src/store/layer.ts
@@ -199,6 +199,13 @@ export const useLayerStore = defineStore("layer", () => {
     selectedLayers.value = [newLayer, ...selectedLayers.value];
   }
 
+  function setLayerVisibility(layers: Layer[], visible = true) {
+    selectedLayers.value = selectedLayers.value.map((layer: Layer) => {
+      if (layers.includes(layer)) layer.visible = visible;
+      return layer;
+    });
+  }
+
   watch(selectedLayers, updateLayersShown);
   watch(framesByLayerId, updateLayersShown);
   function updateLayersShown() {
@@ -285,6 +292,7 @@ export const useLayerStore = defineStore("layer", () => {
     layerFrames,
     updateLayersShown,
     addLayer,
+    setLayerVisibility,
     getDBObjectsForSourceID,
     getBoundsOfVisibleLayers,
     getMapLayersFromLayerObject,


### PR DESCRIPTION
As I was writing the documentation for the legend panel, I found this bug. If two copies of the same layer are added to the map, the eye icon for one copy will toggle the visibility of both copies. We had two slightly different `setVisibility` functions, one for the selected layers panel and one for the legend panel. To resolve the bug I consolidated the logic in a new `layerStore` function, `setLayerVisibility`. Both panels now use the same function to toggle layer visibility.

Edit: I also found a few more things to fix:
1. Use bold text to emphasize substyle names
2. Apply a maximum precision to colormap range labels