### PR TITLE
Fix raster tooltip

### DIFF
--- a/uvdat/core/models/data.py
+++ b/uvdat/core/models/data.py
@@ -15,6 +15,8 @@ from .dataset import Dataset
 from .file_item import FileItem
 from .querysets import ProjectQuerySet
 
+MAX_DATA_SIZE = 500
+
 
 class RasterData(models.Model):
     name = models.CharField(max_length=255, default="Raster Data")
@@ -29,17 +31,20 @@ class RasterData(models.Model):
     def __str__(self):
         return f"{self.name} ({self.id})"
 
-    def get_image_data(self, resolution: float = 1.0):
+    def get_image_data(self):
         with tempfile.TemporaryDirectory() as tmp:
             raster_path = Path(tmp, "raster")
             with raster_path.open("wb") as raster_file:
                 raster_file.write(self.cloud_optimized_geotiff.read())
             source = large_image.open(raster_path)
-            data, _data_format = source.getRegion(format="numpy")
-            data = data[:, :, 0]
-            if resolution != 1.0:
-                step = int(1 / resolution)
-                data = data[::step][::step]
+            data, _ = source.getRegion(
+                format="numpy",
+                output={
+                    "maxWidth": MAX_DATA_SIZE,
+                    "maxHeight": MAX_DATA_SIZE,
+                },
+            )
+            data = data[:, :, 0 : source.metadata.get("bandCount", 1)]
             return data.tolist()
 
 

--- a/uvdat/core/models/data.py
+++ b/uvdat/core/models/data.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
-import tempfile
 
 from django.contrib.gis.db import models as geomodels
 from django.core.files.base import ContentFile
 from django.db import models
 from django.dispatch import receiver
-import large_image
-import numpy as np
 from s3_file_field import S3FileField
 
 from .dataset import Dataset
@@ -29,21 +25,6 @@ class RasterData(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.id})"
-
-    def get_pixel(self, lat, lng):
-        with tempfile.TemporaryDirectory() as tmp:
-            raster_path = Path(tmp, "raster")
-            with raster_path.open("wb") as raster_file:
-                raster_file.write(self.cloud_optimized_geotiff.read())
-            source = large_image.open(raster_path)
-            pixel = source.getPixel(
-                region={
-                    "units": "EPSG:4326",
-                    "right": lng,
-                    "top": lat,
-                }
-            )
-            return np.array(pixel.get("value")).astype(source.dtype)[: source.bandCount].tolist()
 
 
 class VectorData(models.Model):

--- a/uvdat/core/models/data.py
+++ b/uvdat/core/models/data.py
@@ -9,13 +9,12 @@ from django.core.files.base import ContentFile
 from django.db import models
 from django.dispatch import receiver
 import large_image
+import numpy as np
 from s3_file_field import S3FileField
 
 from .dataset import Dataset
 from .file_item import FileItem
 from .querysets import ProjectQuerySet
-
-MAX_DATA_SIZE = 500
 
 
 class RasterData(models.Model):
@@ -31,21 +30,20 @@ class RasterData(models.Model):
     def __str__(self):
         return f"{self.name} ({self.id})"
 
-    def get_image_data(self):
+    def get_pixel(self, lat, lng):
         with tempfile.TemporaryDirectory() as tmp:
             raster_path = Path(tmp, "raster")
             with raster_path.open("wb") as raster_file:
                 raster_file.write(self.cloud_optimized_geotiff.read())
             source = large_image.open(raster_path)
-            data, _ = source.getRegion(
-                format="numpy",
-                output={
-                    "maxWidth": MAX_DATA_SIZE,
-                    "maxHeight": MAX_DATA_SIZE,
-                },
+            pixel = source.getPixel(
+                region={
+                    "units": "EPSG:4326",
+                    "right": lng,
+                    "top": lat,
+                }
             )
-            data = data[:, :, 0 : source.metadata.get("bandCount", 1)]
-            return data.tolist()
+            return np.array(pixel.get("value")).astype(source.dtype)[: source.bandCount].tolist()
 
 
 class VectorData(models.Model):

--- a/uvdat/core/rest/data.py
+++ b/uvdat/core/rest/data.py
@@ -102,12 +102,12 @@ class RasterDataViewSet(GenericDataViewSet, LargeImageFileDetailMixin):
     @action(
         detail=True,
         methods=["get"],
-        url_path=r"raster-data/(?P<resolution>[\d*\.?\d*]+)",
+        url_path="get-data",
         url_name="raster_data",
     )
-    def get_raster_data(self, request, resolution: str = "1", **kwargs):
+    def get_raster_data(self, request, **kwargs):
         raster_data = self.get_object()
-        data = raster_data.get_image_data(float(resolution))
+        data = raster_data.get_image_data()
         return HttpResponse(json.dumps(data), status=200)
 
 

--- a/uvdat/core/rest/data.py
+++ b/uvdat/core/rest/data.py
@@ -99,16 +99,18 @@ class RasterDataViewSet(GenericDataViewSet, LargeImageFileDetailMixin):
     serializer_class = RasterDataSerializer
     FILE_FIELD_NAME = "cloud_optimized_geotiff"
 
-    @action(
-        detail=True,
-        methods=["get"],
-        url_path="get-data",
-        url_name="raster_data",
-    )
-    def get_raster_data(self, request, **kwargs):
-        raster_data = self.get_object()
-        data = raster_data.get_image_data()
-        return HttpResponse(json.dumps(data), status=200)
+    @action(detail=True, methods=["get"])
+    def pixel(self, request, **kwargs):
+        instance = self.get_object()
+        return HttpResponse(
+            json.dumps(
+                instance.get_pixel(
+                    request.query_params.get("lat"),
+                    request.query_params.get("lng"),
+                )
+            ),
+            status=200,
+        )
 
 
 class VectorDataViewSet(GenericDataViewSet):

--- a/uvdat/core/rest/data.py
+++ b/uvdat/core/rest/data.py
@@ -6,6 +6,7 @@ from django.contrib.gis.db.models import Extent
 from django.db import connection
 from django.http import HttpResponse
 from django_large_image.rest import LargeImageFileDetailMixin
+import numpy as np
 from rest_framework import mixins
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -101,14 +102,17 @@ class RasterDataViewSet(GenericDataViewSet, LargeImageFileDetailMixin):
 
     @action(detail=True, methods=["get"])
     def pixel(self, request, **kwargs):
-        instance = self.get_object()
+        source = self.get_tile_source(request)
+        pixel = source.getPixel(
+            region={
+                "units": "EPSG:4326",
+                "right": request.query_params.get("lng"),
+                "top": request.query_params.get("lat"),
+            }
+        )
+        value = np.array(pixel.get("value")).astype(source.dtype)[: source.bandCount].tolist()
         return HttpResponse(
-            json.dumps(
-                instance.get_pixel(
-                    request.query_params.get("lat"),
-                    request.query_params.get("lng"),
-                )
-            ),
+            json.dumps(value),
             status=200,
         )
 

--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -214,10 +214,7 @@ export async function getVectorSummary(
 export async function getRasterDataValues(
   rasterId: number,
 ): Promise<RasterDataValues> {
-  const resolution = 0.1;
-  const data = (
-    await apiClient.get(`rasters/${rasterId}/raster-data/${resolution}/`)
-  ).data;
+  const data = (await apiClient.get(`rasters/${rasterId}/get-data/`)).data;
   const { bounds } = (await apiClient.get(`rasters/${rasterId}/info/metadata/`))
     .data;
   return {

--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -211,16 +211,15 @@ export async function getVectorSummary(
   return (await apiClient.get(`vectors/${vectorId}/summary/`)).data;
 }
 
-export async function getRasterDataValues(
+export async function getRasterPixelValue(
   rasterId: number,
+  position: { lat: number; lng: number },
 ): Promise<RasterDataValues> {
-  const data = (await apiClient.get(`rasters/${rasterId}/get-data/`)).data;
-  const { bounds } = (await apiClient.get(`rasters/${rasterId}/info/metadata/`))
-    .data;
-  return {
-    data,
-    sourceBounds: bounds,
-  };
+  return (
+    await apiClient.get(`rasters/${rasterId}/pixel/`, {
+      params: position,
+    })
+  ).data;
 }
 
 export async function runAnalysis(

--- a/web/src/components/map/MapTooltip.vue
+++ b/web/src/components/map/MapTooltip.vue
@@ -129,7 +129,7 @@ watch(clickedFeature, () => {
     tooltip.remove();
     return;
   }
-  let center = undefined;
+  let center: [number, number] | undefined = undefined;
   if (clickedFeatureSourceType.value === "raster") {
     center = [clickedFeature.value.pos.lng, clickedFeature.value.pos.lat];
   } else if (clickedFeatureSourceType.value === "vector") {

--- a/web/src/components/map/MapTooltip.vue
+++ b/web/src/components/map/MapTooltip.vue
@@ -207,7 +207,7 @@ function toggleNodeHandler() {
     <div v-if="rasterValue === undefined">
       <span>fetching raster data...</span>
     </div>
-    <div v-else class="mr-3">Value: {{ rasterValue }}</div>
+    <div v-else class="mr-3">Band Values: {{ rasterValue }}</div>
   </div>
 </template>
 

--- a/web/src/components/map/MapTooltip.vue
+++ b/web/src/components/map/MapTooltip.vue
@@ -129,15 +129,24 @@ watch(clickedFeature, () => {
     tooltip.remove();
     return;
   }
-  // Set tooltip position. Give feature clicks priority
-  const centroid = turf.centroid(clickedFeature.value.feature);
-  const center = centroid.geometry.coordinates as [number, number];
-  tooltip.setLngLat(center);
-  // This makes the tooltip visible
-  tooltip.addTo(mapStore.getMap(props.compareMap));
-  // Don't zoom to feature if comparing maps
-  if (!compareStore.isComparing) {
-    zoomToFeature();
+  let center = undefined;
+  if (clickedFeatureSourceType.value === "raster") {
+    center = [clickedFeature.value.pos.lng, clickedFeature.value.pos.lat];
+  } else if (clickedFeatureSourceType.value === "vector") {
+    const centroid = turf.centroid(clickedFeature.value.feature);
+    center = centroid.geometry.coordinates as [number, number];
+  }
+  if (center) {
+    tooltip.setLngLat(center);
+    // This makes the tooltip visible
+    tooltip.addTo(mapStore.getMap(props.compareMap));
+    // Don't zoom to feature if comparing maps
+    if (
+      !compareStore.isComparing &&
+      clickedFeatureSourceType.value === "vector"
+    ) {
+      zoomToFeature();
+    }
   }
 });
 

--- a/web/src/components/map/MapTooltip.vue
+++ b/web/src/components/map/MapTooltip.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import * as turf from "@turf/turf";
-import proj4 from "proj4";
-
 import RecursiveTable from "../RecursiveTable.vue";
 import { useMapStore, useLayerStore, useNetworkStore } from "@/store";
 import { useMapCompareStore } from "@/store/compare";
+import { getRasterPixelValue } from "@/api/rest";
 
 const layerStore = useLayerStore();
 const networkStore = useNetworkStore();
@@ -66,27 +65,7 @@ const clickedFeatureSourceType = computed(() => {
   return undefined;
 });
 
-const rasterValue = computed(() => {
-  if (clickedFeature.value && clickedFeatureSourceType.value === "raster") {
-    const feature = clickedFeature.value.feature;
-    const { raster } = layerStore.getDBObjectsForSourceID(feature.source);
-    if (raster?.id) {
-      const data = mapStore.rasterTooltipDataCache[raster.id]?.data;
-      if (data) {
-        const { lng, lat } = clickedFeature.value.pos;
-        const { srs } = raster.metadata.bounds;
-        let { xmin, xmax, ymin, ymax } = raster.metadata.bounds;
-        [xmin, ymin] = proj4(srs, "EPSG:4326", [xmin, ymin]);
-        [xmax, ymax] = proj4(srs, "EPSG:4326", [xmax, ymax]);
-        // Convert lat/lng to array indices
-        const x = Math.floor(((lng - xmin) / (xmax - xmin)) * data[0].length);
-        const y = Math.floor((1 - (lat - ymin) / (ymax - ymin)) * data.length);
-        return data[y][x];
-      }
-    }
-  }
-  return undefined;
-});
+const rasterPixel = ref();
 
 function zoomToFeature() {
   if (clickedFeature.value === undefined) {
@@ -132,6 +111,15 @@ watch(clickedFeature, () => {
   let center: [number, number] | undefined = undefined;
   if (clickedFeatureSourceType.value === "raster") {
     center = [clickedFeature.value.pos.lng, clickedFeature.value.pos.lat];
+    const { raster } = layerStore.getDBObjectsForSourceID(
+      clickedFeature.value.feature.source,
+    );
+    if (raster) {
+      rasterPixel.value = undefined;
+      getRasterPixelValue(raster.id, clickedFeature.value.pos).then(
+        (v) => (rasterPixel.value = v),
+      );
+    }
   } else if (clickedFeatureSourceType.value === "vector") {
     const centroid = turf.centroid(clickedFeature.value.feature);
     center = centroid.geometry.coordinates as [number, number];
@@ -204,10 +192,10 @@ function toggleNodeHandler() {
 
   <!-- Check for raster tooltip data after, to give clicked features priority -->
   <div v-else-if="clickedFeatureSourceType === 'raster'">
-    <div v-if="rasterValue === undefined">
-      <span>fetching raster data...</span>
+    <div v-if="rasterPixel === undefined">
+      <span>Fetching raster pixel...</span>
     </div>
-    <div v-else class="mr-3">Band Values: {{ rasterValue }}</div>
+    <div v-else class="mr-3">Pixel Value: {{ rasterPixel }}</div>
   </div>
 </template>
 

--- a/web/src/store/map.ts
+++ b/web/src/store/map.ts
@@ -4,7 +4,6 @@ import type {
   ClickedFeatureData,
   Project,
   RasterData,
-  RasterDataValues,
   VectorData,
   LayerFrame,
   MapLibreLayerWithMetadata,
@@ -19,7 +18,7 @@ import type {
   LayerSpecification,
 } from "maplibre-gl";
 import { Map, Popup } from "maplibre-gl";
-import { getBasemaps, getRasterDataValues } from "@/api/rest";
+import { getBasemaps } from "@/api/rest";
 import { baseURL } from "@/api/auth";
 import proj4 from "proj4";
 import { useStyleStore, useLayerStore, useAppStore, useProjectStore } from ".";
@@ -135,9 +134,6 @@ export const useMapStore = defineStore("map", () => {
   const compareTooltipOverlay = ref<Popup>();
   const clickedFeature = ref<ClickedFeatureData>();
   const compareClickedFeature = ref<ClickedFeatureData>();
-  const rasterTooltipDataCache = ref<
-    Record<number, RasterDataValues | undefined>
-  >({});
   const rasterSourceTileURLs = ref<Record<string, string>>({});
 
   const styleStore = useStyleStore();
@@ -493,14 +489,6 @@ export const useMapStore = defineStore("map", () => {
     map.on("click", boundsLayerId, handleLayerClick);
   }
 
-  async function cacheRasterData(raster: RasterData) {
-    if (rasterTooltipDataCache.value[raster.id] !== undefined) {
-      return;
-    }
-    const data = await getRasterDataValues(raster.id);
-    rasterTooltipDataCache.value[raster.id] = data;
-  }
-
   function createVectorTileSource(
     vector: VectorData,
     sourceId: string,
@@ -580,7 +568,6 @@ export const useMapStore = defineStore("map", () => {
 
     if (tileSource && boundsSource) {
       createRasterFeatureMapLayers(tileSource, boundsSource, multiFrame);
-      cacheRasterData(raster);
       return tileSource;
     }
   }
@@ -620,7 +607,6 @@ export const useMapStore = defineStore("map", () => {
     compareTooltipOverlay,
     clickedFeature,
     compareClickedFeature,
-    rasterTooltipDataCache,
     rasterSourceTileURLs,
     // Functions
     getBaseLayerSourceIds,
@@ -644,7 +630,6 @@ export const useMapStore = defineStore("map", () => {
     createVectorTileSource,
     createRasterTileSource,
     addLayerFrameToMap,
-    cacheRasterData,
     sourceIdFromMapLayerId,
     parseSourceString,
     parseLayerString,

--- a/web/src/store/map.ts
+++ b/web/src/store/map.ts
@@ -476,8 +476,9 @@ export const useMapStore = defineStore("map", () => {
       metadata,
     });
 
+    const boundsLayerId = boundsSource.id + ".fill";
     map.addLayer({
-      id: boundsSource.id + ".fill",
+      id: boundsLayerId,
       type: "fill",
       source: boundsSource.id,
       paint: {
@@ -489,7 +490,7 @@ export const useMapStore = defineStore("map", () => {
       metadata: { ...metadata, multiFrame: false },
     });
 
-    map.on("click", boundsSource.id, handleLayerClick);
+    map.on("click", boundsLayerId, handleLayerClick);
   }
 
   async function cacheRasterData(raster: RasterData) {


### PR DESCRIPTION
The raster value tooltip is one of the older visualization features, and it's been broken for a while. The `handleLayerClick` function was not registered properly on raster bounds layers. This PR fixes that bug so that the map tooltip will show a raster's pixel value when a raster layer is clicked.

More importantly, though, @brianhelba and I discovered that the API call to get the data for the raster tooltip was causing OOM errors in production when called on the Boston Orthoimagery layer, which is relatively large. The `get_image_data` function on the `RasterData` model accepted a resolution argument, and we were sending in a constant resolution value of `0.1`. But the resolution value was applied after getting the full-res data from large_image's `getRegion`. Loading the full orthoimagery layer into memory was exceeding Heroku's memory limits. 

This PR updates the `get_image_data` function to pass a `maxWidth` and `maxHeight` to `getRegion`. We define the maximum size as a constant on the server (rather than allowing the user to specify the size via the API and possibly exceed the memory limit, which would leave us vulnerable to DOS).

Lastly, this PR changes the format of the raster tooltip. Instead of assuming that we only want the value from the first band, we now display all band values as an array.