### PR TITLE
Remove redundant layer visibility controls in legend panel

### DIFF
--- a/web/src/components/sidebars/LegendPanel.vue
+++ b/web/src/components/sidebars/LegendPanel.vue
@@ -116,16 +116,11 @@ function getColorPropsCoverage(layer: Layer) {
     <v-card class="panel-content-inner">
       <v-list v-if="filteredLegend?.length" density="compact">
         <v-list-item v-for="layer in filteredLegend" :key="layer.id">
-          <v-icon
-            :icon="layer.visible ? 'mdi-eye-outline' : 'mdi-eye-off-outline'"
-            class=""
-            @click="layerStore.setLayerVisibility([layer], !layer.visible)"
-          />
           {{ layer.name }}
           <div
             v-for="colormap_preview in getColormapPreviews(layer)"
             :key="colormap_preview.name"
-            class="ml-6"
+            class="ml-2"
           >
             <div
               v-if="getColormapPreviews(layer).length > 1"


### PR DESCRIPTION
I asked @faiza-a about the duplicate controls we currently have for layer visibility. We use checkboxes in the selected layers panel and eye icons in the legend panel; these controls are synced. Having two different controls for the same thing is redundant and possibly confusing. 
<img width="610" height="307" alt="image" src="https://github.com/user-attachments/assets/a4a8f90c-ccf3-492f-8e81-e7f59bd7d6b3" />

Faiza pointed out that we don't need the controls in the legend panel, so this PR removes them. Going forward, the legend panel will be a read-only summary of the state configured in the selected layers panel.