### PR TITLE
Fix follower permissions

### DIFF
--- a/uvdat/core/models/project.py
+++ b/uvdat/core/models/project.py
@@ -52,6 +52,9 @@ class Project(models.Model):
             "list[User]", list(get_users_with_perms(self, only_with_perms_in=["follower"]))
         )
 
+    def user_can_edit(self, user):
+        return user.is_superuser or self.owner() == user or user in self.collaborators()
+
     @transaction.atomic()
     def delete_users_perms(self, users: list[User]):
         """Delete all permissions a user may have on this project."""

--- a/uvdat/core/rest/analytics.py
+++ b/uvdat/core/rest/analytics.py
@@ -92,14 +92,10 @@ class AnalyticsViewSet(ReadOnlyModelViewSet):
     )
     def run(self, request, project_id: int, task_type: str, **kwargs):
         project = Project.objects.get(id=project_id)
-        if (
-            not request.user.is_superuser
-            and project.owner() != request.user
-            and request.user not in project.collaborators()
-        ):
+        if not project.user_can_edit(request.user):
             return Response(
                 "You do not have permission to run analytics tasks in this project.",
-                status=400,
+                status=403,
             )
         analysis_type_class = next(
             iter(at for at in analysis_types if at().db_value == task_type), None

--- a/uvdat/core/rest/analytics.py
+++ b/uvdat/core/rest/analytics.py
@@ -96,6 +96,15 @@ class AnalyticsViewSet(ReadOnlyModelViewSet):
     )
     def run(self, request, project_id: int, task_type: str, **kwargs):
         project = Project.objects.get(id=project_id)
+        if (
+            not request.user.is_superuser
+            and project.owner() != request.user
+            and request.user not in project.collaborators()
+        ):
+            return Response(
+                "You do not have permission to run analytics tasks in this project.",
+                status=400,
+            )
         analysis_type_class = next(
             iter(at for at in analysis_types if at().db_value == task_type), None
         )

--- a/uvdat/core/rest/analytics.py
+++ b/uvdat/core/rest/analytics.py
@@ -25,10 +25,6 @@ class AnalyticsViewSet(ReadOnlyModelViewSet):
         url_path=r"project/(?P<project_id>[\d*]+)/types",
     )
     def list_types(self, request, project_id: int, **kwargs):
-        # TODO: remove this when analytics are ready to be shown to all users
-        if not request.user.is_superuser:
-            return Response([], status=200)
-
         serialized = []
         for analysis_type in analysis_types:
             if not analysis_type.is_enabled():

--- a/uvdat/core/rest/colormap.py
+++ b/uvdat/core/rest/colormap.py
@@ -15,14 +15,10 @@ class ColormapViewSet(ModelViewSet):
 
     def create(self, request, **kwargs):
         project = Project.objects.get(id=request.data.get("project"))
-        if not (
-            request.user.is_superuser
-            or project.owner == request.user
-            or request.user in project.collaborators()
-        ):
+        if not project.user_can_edit(request.user):
             return Response(
                 "You do not have permission to create colormaps in this project.",
-                status=400,
+                status=403,
             )
         serializer = ColormapSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/uvdat/core/rest/colormap.py
+++ b/uvdat/core/rest/colormap.py
@@ -1,11 +1,34 @@
 from __future__ import annotations
 
+from django.db import transaction
+import jsonschema
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from uvdat.core.models import Colormap
+from uvdat.core.models import Colormap, Project
 from uvdat.core.rest.serializers import ColormapSerializer
 
 
 class ColormapViewSet(ModelViewSet):
     queryset = Colormap.objects.all()
     serializer_class = ColormapSerializer
+
+    def create(self, request, **kwargs):
+        project = Project.objects.get(id=request.data.get("project"))
+        if not (
+            request.user.is_superuser
+            or project.owner == request.user
+            or request.user in project.collaborators()
+        ):
+            return Response(
+                "You do not have permission to create colormaps in this project.",
+                status=400,
+            )
+        serializer = ColormapSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        with transaction.atomic():
+            try:
+                serializer.save()
+            except jsonschema.exceptions.ValidationError as e:
+                return Response(e.message, status=400)
+        return Response(serializer.data, status=200)

--- a/uvdat/core/rest/layer.py
+++ b/uvdat/core/rest/layer.py
@@ -47,14 +47,10 @@ class LayerStyleViewSet(ModelViewSet):
 
     def create(self, request, **kwargs):
         project = Project.objects.get(id=request.data.get("project"))
-        if not (
-            request.user.is_superuser
-            or project.owner == request.user
-            or request.user in project.collaborators()
-        ):
+        if not project.user_can_edit(request.user):
             return Response(
                 "You do not have permission to create styles in this project.",
-                status=400,
+                status=403,
             )
         is_default = request.data.pop("is_default", False)
         serializer = LayerStyleSerializer(data=request.data)

--- a/uvdat/core/rest/layer.py
+++ b/uvdat/core/rest/layer.py
@@ -6,7 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
-from uvdat.core.models import Layer, LayerFrame, LayerStyle
+from uvdat.core.models import Layer, LayerFrame, LayerStyle, Project
 from uvdat.core.rest.serializers import (
     LayerFrameSerializer,
     LayerSerializer,
@@ -46,6 +46,16 @@ class LayerStyleViewSet(ModelViewSet):
         return qs
 
     def create(self, request, **kwargs):
+        project = Project.objects.get(id=request.data.get("project"))
+        if not (
+            request.user.is_superuser
+            or project.owner == request.user
+            or request.user in project.collaborators()
+        ):
+            return Response(
+                "You do not have permission to create styles in this project.",
+                status=400,
+            )
         is_default = request.data.pop("is_default", False)
         serializer = LayerStyleSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/uvdat/core/rest/project.py
+++ b/uvdat/core/rest/project.py
@@ -35,7 +35,9 @@ class ProjectViewSet(ModelViewSet):
         # Only the owner can modify project permissions
         project: Project = self.get_object()
         if not user.has_perm("owner", project):
-            return Response(status=403)
+            return Response(
+                "You do not have permission to modify access control on this project.", status=403
+            )
 
         serializer = ProjectPermissionsSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/uvdat/core/rest/view_state.py
+++ b/uvdat/core/rest/view_state.py
@@ -15,14 +15,10 @@ class ViewStateViewSet(ModelViewSet):
 
     def create(self, request, **kwargs):
         project = Project.objects.get(id=request.data.get("project"))
-        if not (
-            request.user.is_superuser
-            or project.owner == request.user
-            or request.user in project.collaborators()
-        ):
+        if not project.user_can_edit(request.user):
             return Response(
                 "You do not have permission to create view states in this project.",
-                status=400,
+                status=403,
             )
         serializer = ViewStateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/uvdat/core/rest/view_state.py
+++ b/uvdat/core/rest/view_state.py
@@ -1,11 +1,34 @@
 from __future__ import annotations
 
+from django.db import transaction
+import jsonschema
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from uvdat.core.models import ViewState
+from uvdat.core.models import Project, ViewState
 from uvdat.core.rest.serializers import ViewStateSerializer
 
 
 class ViewStateViewSet(ModelViewSet):
     queryset = ViewState.objects.all()
     serializer_class = ViewStateSerializer
+
+    def create(self, request, **kwargs):
+        project = Project.objects.get(id=request.data.get("project"))
+        if not (
+            request.user.is_superuser
+            or project.owner == request.user
+            or request.user in project.collaborators()
+        ):
+            return Response(
+                "You do not have permission to create view states in this project.",
+                status=400,
+            )
+        serializer = ViewStateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        with transaction.atomic():
+            try:
+                serializer.save()
+            except jsonschema.exceptions.ValidationError as e:
+                return Response(e.message, status=400)
+        return Response(serializer.data, status=200)

--- a/uvdat/core/tests/test_analytics.py
+++ b/uvdat/core/tests/test_analytics.py
@@ -15,10 +15,6 @@ from uvdat.core.tasks.analytics import (
 
 @pytest.mark.django_db
 def test_rest_list_analysis_types(user, authenticated_api_client, project):
-    # TODO: remove this when analytics are no longer hidden from non-superusers
-    user.is_superuser = True
-    user.save()
-
     analysis_type_instances = [at() for at in analysis_types if at.is_enabled()]
     resp = authenticated_api_client.get(f"/api/v1/analytics/project/{project.id}/types/")
     data = resp.json()

--- a/uvdat/core/tests/test_analytics.py
+++ b/uvdat/core/tests/test_analytics.py
@@ -49,7 +49,7 @@ def test_rest_list_analysis_types(user, authenticated_api_client, project):
 )
 @pytest.mark.django_db
 def test_rest_run_analysis_task_no_inputs(authenticated_api_client, user, project, task):
-    project.set_followers([user])
+    project.set_collaborators([user])
     resp = authenticated_api_client.post(
         f"/api/v1/analytics/project/{project.id}/types/{task}/run/"
     )
@@ -59,7 +59,7 @@ def test_rest_run_analysis_task_no_inputs(authenticated_api_client, user, projec
 
 @pytest.mark.django_db
 def test_rest_run_analysis_task_creator(authenticated_api_client, user, project):
-    project.set_followers([user])
+    project.set_collaborators([user])
     resp = authenticated_api_client.post(
         f"/api/v1/analytics/project/{project.id}/types/create_road_network/run/",
         # Smallest town in America, only 7 nodes

--- a/web/src/components/ControlsBar.vue
+++ b/web/src/components/ControlsBar.vue
@@ -67,16 +67,13 @@ const newViewStateValid = computed(() => {
       .includes(newViewStateName.value)
   );
 });
-const userHasEditPermission = computed(() => {
-  const user = appStore.currentUser;
-  const project = projectStore.currentProject;
-  return (
-    user?.is_superuser ||
-    (project &&
-      user &&
-      (project.owner.id === user.id ||
-        project.collaborators.map((u) => u.id).includes(user.id)))
-  );
+const editMode = computed(() => {
+  if (projectStore.currentProject) {
+    return ["owner", "collaborator"].includes(
+      projectStore.permissions[projectStore.currentProject.id],
+    );
+  }
+  return false;
 });
 
 function createBasemapPreviews() {
@@ -427,7 +424,11 @@ watch(newBasemapStyleJSON, debounce(createNewBasemapPreview, 1000));
               While using map comparison mode, saving a new view state is not
               supported.
             </div>
-            <v-btn v-else class="control-menu-row" @click="showViewStateDialog">
+            <v-btn
+              v-else-if="editMode"
+              class="control-menu-row"
+              @click="showViewStateDialog"
+            >
               <div>Save current view state</div>
             </v-btn>
             <v-list
@@ -451,7 +452,7 @@ watch(newBasemapStyleJSON, debounce(createNewBasemapPreview, 1000));
                 </template>
                 <template #append>
                   <v-btn
-                    v-if="userHasEditPermission"
+                    v-if="editMode"
                     v-tooltip="'Delete this view state'"
                     icon="mdi-delete"
                     flat
@@ -591,7 +592,7 @@ watch(newBasemapStyleJSON, debounce(createNewBasemapPreview, 1000));
         </v-card-actions>
       </v-card>
     </v-dialog>
-    <v-dialog :model-value="showViewStateCreation" width="500">
+    <v-dialog v-if="editMode" :model-value="showViewStateCreation" width="500">
       <v-card>
         <v-card-title class="pa-3">
           New View State
@@ -639,7 +640,11 @@ watch(newBasemapStyleJSON, debounce(createNewBasemapPreview, 1000));
         </v-card-actions>
       </v-card>
     </v-dialog>
-    <v-dialog :model-value="viewStateToDelete !== undefined" width="500">
+    <v-dialog
+      v-if="editMode"
+      :model-value="viewStateToDelete !== undefined"
+      width="500"
+    >
       <v-card>
         <v-card-title>
           Delete View State

--- a/web/src/components/projects/AccessControl.vue
+++ b/web/src/components/projects/AccessControl.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, computed, ref } from "vue";
 import type { Ref } from "vue";
 import type { Project, ProjectPermissions, User } from "@/types";
 import { getUsers, updateProjectPermissions } from "@/api/rest";
 
+import { useProjectStore } from "@/store";
+const projectStore = useProjectStore();
+
 const props = defineProps<{
   project: Project;
-  permissions: Record<number, string>;
 }>();
 const emit = defineEmits(["updateSelectedProject"]);
 const allUsers: Ref<User[]> = ref([]);
@@ -17,8 +19,12 @@ type PermissionLevel = "follower" | "collaborator";
 const permissionLevels: PermissionLevel[] = ["follower", "collaborator"];
 const selectedPermissionLevel: Ref<PermissionLevel> = ref("follower");
 const userToRemove: Ref<User | undefined> = ref();
+const editMode = computed(
+  () => projectStore.permissions[props.project.id] === "owner",
+);
 
 function savePermissions() {
+  if (!editMode.value) return;
   let owner: number = props.project.owner.id;
   const collaborators = new Set(
     props.project.collaborators.map((u: User) => u.id),
@@ -111,7 +117,7 @@ onMounted(() => {
         </template>
         <template #append>
           <v-icon
-            v-if="permissions[project.id] === 'owner'"
+            v-if="editMode"
             icon="mdi-pencil"
             @click="
               showUserSelectDialog = true;
@@ -156,7 +162,7 @@ onMounted(() => {
         </template>
         <template #append>
           <v-icon
-            v-if="permissions[project.id] === 'owner'"
+            v-if="editMode"
             icon="mdi-trash-can"
             @click="userToRemove = collaborator"
           />
@@ -203,7 +209,7 @@ onMounted(() => {
         </template>
         <template #append>
           <v-icon
-            v-if="permissions[project.id] === 'owner'"
+            v-if="editMode"
             icon="mdi-trash-can"
             @click="userToRemove = follower"
           />
@@ -216,7 +222,7 @@ onMounted(() => {
       />
     </v-list>
     <v-btn
-      v-if="permissions[project.id] === 'owner'"
+      v-if="editMode"
       color="primary"
       @click="
         showUserSelectDialog = true;

--- a/web/src/components/projects/DatasetSelect.vue
+++ b/web/src/components/projects/DatasetSelect.vue
@@ -22,6 +22,7 @@ const props = defineProps<{
   addedIds?: number[] | undefined;
   buttonIcon: string;
   showDelete: boolean;
+  editMode: boolean;
 }>();
 const emit = defineEmits(["buttonClick", "onDelete"]);
 const datasetToDelete = ref<Dataset>();
@@ -95,7 +96,7 @@ function submitDelete() {
                     @click.stop="datasetToDelete = dataset"
                   />
                 </div>
-                <div class="mr-2">
+                <div v-if="editMode" class="mr-2">
                   <div
                     v-if="
                       conversionStore.datasetConversionTasks[dataset.id] &&

--- a/web/src/components/projects/DatasetUpload.vue
+++ b/web/src/components/projects/DatasetUpload.vue
@@ -26,7 +26,7 @@ interface LayerSpec {
 
 const props = defineProps<{
   allDatasets: Dataset[];
-  projectPermission: any;
+  editMode: boolean;
 }>();
 const emit = defineEmits(["addToCurrentProject", "uploaded"]);
 
@@ -79,13 +79,10 @@ const valid = computed(() => {
     })
   );
 });
-const canEditProject = computed(() => {
-  return ["owner", "collaborator"].includes(props.projectPermission);
-});
 
 function init() {
   addLayer();
-  if (canEditProject.value) {
+  if (props.editMode) {
     addToCurrentProject.value = true;
   }
 }
@@ -468,7 +465,7 @@ watch(open, () => {
 
         <div class="d-flex px-3" style="justify-content: right">
           <v-checkbox
-            v-if="canEditProject"
+            v-if="editMode"
             v-model="addToCurrentProject"
             label="Add dataset to current project"
             density="compact"

--- a/web/src/components/projects/ProjectConfig.vue
+++ b/web/src/components/projects/ProjectConfig.vue
@@ -12,9 +12,8 @@ import {
 } from "@/api/rest";
 import type { Project, Dataset } from "@/types";
 
-import { useMapStore, useAppStore, useProjectStore } from "@/store";
+import { useMapStore, useProjectStore } from "@/store";
 const projectStore = useProjectStore();
-const appStore = useAppStore();
 const mapStore = useMapStore();
 
 const currentTab = ref();
@@ -30,34 +29,25 @@ const filteredProjects = computed(() => {
 const selectedProject: Ref<Project | undefined> = ref();
 const projDatasets: Ref<Dataset[] | undefined> = ref();
 
-const permissions = computed(() => {
-  const ret = Object.fromEntries(
-    projectStore.availableProjects.map((p) => {
-      let perm = "follower";
-      if (p.id === selectedProject.value?.id) {
-        p = selectedProject.value;
-      }
-      if (
-        p.owner?.id === appStore.currentUser?.id ||
-        appStore.currentUser?.is_superuser
-      ) {
-        perm = "owner";
-      } else if (
-        appStore.currentUser &&
-        p.collaborators.map((u) => u.id).includes(appStore.currentUser.id)
-      ) {
-        perm = "collaborator";
-      }
-      return [p.id, perm];
-    }),
-  );
-  return ret;
-});
 const saving = ref<"waiting" | "done">();
 const savingId = ref<number | undefined>();
 const newProjectName = ref();
 const projectToEdit: Ref<Project | undefined> = ref();
 const projectToDelete: Ref<Project | undefined> = ref();
+const editMode = computed(() => {
+  if (selectedProject.value) {
+    return ["owner", "collaborator"].includes(
+      projectStore.permissions[selectedProject.value.id],
+    );
+  }
+  return false;
+});
+const deleteAllowed = computed(() => {
+  if (selectedProject.value) {
+    return projectStore.permissions[selectedProject.value.id] === "owner";
+  }
+  return false;
+});
 
 function openProjectConfig(create = false) {
   projectStore.projectConfigMode = create ? "new" : "existing";
@@ -74,7 +64,7 @@ function create() {
 }
 
 function del() {
-  if (projectToDelete.value) {
+  if (projectToDelete.value && deleteAllowed.value) {
     deleteProject(projectToDelete.value.id).then(() => {
       projectStore.loadProjects();
       if (selectedProject.value?.id === projectToDelete.value?.id) {
@@ -86,6 +76,7 @@ function del() {
 }
 
 function saveProjectName() {
+  if (!editMode.value) return;
   if (!newProjectName.value) {
     projectToEdit.value = undefined;
     return;
@@ -107,6 +98,7 @@ function saveProjectName() {
 }
 
 function saveProjectMapLocation(project: Project | undefined) {
+  if (!editMode.value) return;
   if (project) {
     saving.value = "waiting";
     const { center, zoom } = mapStore.getCurrentMapPosition();
@@ -173,6 +165,7 @@ function removeDatasetFromProject(dataset: Dataset) {
 }
 
 function saveDatasetsToProject(ids: number[]) {
+  if (!editMode.value) return;
   if (selectedProject.value) {
     patchProject(selectedProject.value.id, {
       datasets: ids,
@@ -330,6 +323,7 @@ watch(
               Go to project default map position
             </v-list-item>
             <v-list-item
+              v-if="editMode"
               @click="() => saveProjectMapLocation(projectStore.currentProject)"
             >
               Set current map position as project default
@@ -409,11 +403,7 @@ watch(
                 <span v-else>{{ title }}</span>
               </template>
               <template #append>
-                <div
-                  v-if="
-                    ['owner', 'collaborator'].includes(permissions[project.id])
-                  "
-                >
+                <div v-if="editMode">
                   <v-icon
                     v-if="!projectToEdit && !projectToDelete"
                     icon="mdi-pencil"
@@ -430,7 +420,7 @@ watch(
                     <v-icon icon="mdi-content-save" />
                   </v-btn>
                 </div>
-                <div v-if="['owner'].includes(permissions[project.id])">
+                <div v-if="deleteAllowed">
                   <v-icon
                     v-if="!projectToEdit && !projectToDelete"
                     icon="mdi-trash-can"
@@ -501,18 +491,19 @@ watch(
                     :saving-id="savingId"
                     :show-delete="false"
                     button-icon="mdi-close"
+                    :edit-mode="editMode"
                     @button-click="removeDatasetFromProject"
                     @on-delete="refreshProjectDatasets"
                   />
                 </div>
               </div>
               <v-divider class="mx-5" vertical></v-divider>
-              <div style="width: 45%">
+              <div v-if="editMode" style="width: 45%">
                 <div class="d-flex">
                   <v-card-text>All Datasets</v-card-text>
                   <DatasetUpload
                     :all-datasets="projectStore.allDatasets"
-                    :project-permission="permissions[selectedProject.id]"
+                    :edit-mode="editMode"
                     @add-to-current-project="addDatasetToProject"
                     @uploaded="datasetUploaded"
                   />
@@ -524,6 +515,7 @@ watch(
                     :added-ids="projDatasets?.map((d) => d.id)"
                     :show-delete="true"
                     button-icon="mdi-plus"
+                    :edit-mode="editMode"
                     @button-click="addDatasetToProject"
                     @on-delete="refreshProjectDatasets"
                   />
@@ -534,7 +526,6 @@ watch(
           <div v-if="currentTab === 'users'" class="py-3 px-6">
             <AccessControl
               :project="selectedProject"
-              :permissions="permissions"
               @update-selected-project="updateSelectedProject"
             />
           </div>
@@ -557,7 +548,9 @@ watch(
             Are you sure you want to delete "{{ projectToDelete.name }}"?
           </v-card-text>
           <v-card-actions class="d-flex" style="justify-content: space-evenly">
-            <v-btn color="red" @click="del">Delete</v-btn>
+            <v-btn color="red" :disabled="!deleteAllowed" @click="del"
+              >Delete</v-btn
+            >
             <v-btn
               color="primary"
               variant="tonal"

--- a/web/src/components/projects/ProjectConfig.vue
+++ b/web/src/components/projects/ProjectConfig.vue
@@ -403,7 +403,13 @@ watch(
                 <span v-else>{{ title }}</span>
               </template>
               <template #append>
-                <div v-if="editMode">
+                <div
+                  v-if="
+                    ['owner', 'collaborator'].includes(
+                      projectStore.permissions[project.id],
+                    )
+                  "
+                >
                   <v-icon
                     v-if="!projectToEdit && !projectToDelete"
                     icon="mdi-pencil"
@@ -420,7 +426,11 @@ watch(
                     <v-icon icon="mdi-content-save" />
                   </v-btn>
                 </div>
-                <div v-if="deleteAllowed">
+                <div
+                  v-if="
+                    ['owner'].includes(projectStore.permissions[project.id])
+                  "
+                >
                   <v-icon
                     v-if="!projectToEdit && !projectToDelete"
                     icon="mdi-trash-can"

--- a/web/src/components/sidebars/AnalyticsPanel.vue
+++ b/web/src/components/sidebars/AnalyticsPanel.vue
@@ -77,8 +77,15 @@ const selectedInputs = ref<Record<string, any>>({});
 const inputSelectionRules = [(v: any) => (v ? true : "Input required.")];
 const additionalAnimationLayers = ref();
 const inputForm = ref();
+const runAllowed = computed(() => {
+  if (!projectStore.currentProject) return false;
+  return ["owner", "collaborator"].includes(
+    projectStore.permissions[projectStore.currentProject.id],
+  );
+});
 
 function run() {
+  if (!runAllowed.value) return;
   inputForm.value.validate().then(({ valid }: { valid: boolean }) => {
     if (
       valid &&
@@ -309,6 +316,7 @@ watch(
         </v-expansion-panels>
 
         <v-tabs
+          v-if="runAllowed"
           v-model="analysisStore.currentAnalysisTab"
           align-tabs="center"
           fixed-tabs
@@ -318,7 +326,7 @@ watch(
         </v-tabs>
 
         <v-window v-model="analysisStore.currentAnalysisTab">
-          <v-window-item value="new">
+          <v-window-item v-if="runAllowed" value="new">
             <v-form ref="inputForm" class="pa-3" @submit.prevent>
               <v-card-subtitle class="px-1">Select inputs</v-card-subtitle>
               <div

--- a/web/src/components/sidebars/LayerStyle.vue
+++ b/web/src/components/sidebars/LayerStyle.vue
@@ -65,17 +65,11 @@ const highlightFilterId = ref<number | undefined>();
 // for correct typing in template, assign to computed variable
 const colormaps = computed(() => styleStore.colormaps);
 
-const projectPermission = computed(() => {
-  if (!projectStore.currentProject || !appStore.currentUser) return "none";
-  const user = appStore.currentUser;
-  const proj = projectStore.currentProject;
-  let perm = "follower";
-  if (proj.owner?.id === user.id || user.is_superuser) {
-    perm = "owner";
-  } else if (proj.collaborators.map((u) => u.id).includes(user.id)) {
-    perm = "collaborator";
-  }
-  return perm;
+const editMode = computed(() => {
+  if (!projectStore.currentProject || !appStore.currentUser) return false;
+  return ["owner", "collaborator"].includes(
+    projectStore.permissions[projectStore.currentProject.id],
+  );
 });
 
 const styleKey = computed(() => {
@@ -343,12 +337,14 @@ function setGroupColormap(groupName: string, colormap: Colormap) {
 }
 
 function openColormapEditor(groupName: string, colormap: Colormap | undefined) {
+  if (!editMode.value) return;
   showColormapEditor.value = true;
   editColormapGroupName.value = groupName;
   editColormap.value = colormap;
 }
 
 function confirmDeleteColormap() {
+  if (!editMode.value) return;
   if (delColormap.value?.id) {
     deleteColormap(delColormap.value.id).then(() => {
       delColormap.value = undefined;
@@ -499,7 +495,12 @@ function cancel() {
 }
 
 function save() {
-  if (!currentLayerStyle.value?.id || !currentStyleSpec.value) return;
+  if (
+    !editMode.value ||
+    !currentLayerStyle.value?.id ||
+    !currentStyleSpec.value
+  )
+    return;
   updateLayerStyle(currentLayerStyle.value.id, {
     name: newName.value || currentLayerStyle.value.name,
     is_default: currentLayerStyle.value.is_default,
@@ -520,7 +521,12 @@ function save() {
 }
 
 function saveAsNew() {
-  if (!projectStore.currentProject || !currentStyleSpec.value) return;
+  if (
+    !editMode.value ||
+    !projectStore.currentProject ||
+    !currentStyleSpec.value
+  )
+    return;
   createLayerStyle({
     ...currentLayerStyle.value,
     name: newName.value,
@@ -543,7 +549,7 @@ function saveAsNew() {
 }
 
 function deleteStyle() {
-  if (!currentLayerStyle.value?.id) return;
+  if (!editMode.value || !currentLayerStyle.value?.id) return;
   deleteLayerStyle(currentLayerStyle.value.id).then(() => {
     getLayerStyles(props.layer.id).then((styles) => {
       availableStyles.value = styles;
@@ -673,6 +679,7 @@ onMounted(resetCurrentStyle);
             @update:model-value="selectStyle"
           ></v-select>
           <v-menu
+            v-if="editMode"
             v-model="showEditOptions"
             open-on-hover
             :close-on-content-click="false"
@@ -704,7 +711,7 @@ onMounted(resetCurrentStyle);
           </v-menu>
         </div>
 
-        <div class="d-flex mx-2">
+        <div v-if="editMode" class="d-flex mx-2">
           <v-checkbox
             v-model="currentLayerStyle.is_default"
             label="Set as default style"
@@ -928,10 +935,9 @@ onMounted(resetCurrentStyle);
                               <template #append>
                                 <v-icon
                                   v-if="
-                                    item.project &&
-                                    ['owner', 'collaborator'].includes(
-                                      projectPermission,
-                                    )
+                                    item.project ==
+                                      projectStore.currentProject?.id &&
+                                    editMode
                                   "
                                   icon="mdi-pencil"
                                   class="ml-2"
@@ -939,10 +945,9 @@ onMounted(resetCurrentStyle);
                                 />
                                 <v-icon
                                   v-if="
-                                    item.project &&
-                                    ['owner', 'collaborator'].includes(
-                                      projectPermission,
-                                    )
+                                    item.project ==
+                                      projectStore.currentProject?.id &&
+                                    editMode
                                   "
                                   icon="mdi-trash-can"
                                   class="ml-2"
@@ -986,11 +991,7 @@ onMounted(resetCurrentStyle);
                           </template>
                           <template #prepend-item>
                             <v-list-item
-                              v-if="
-                                ['owner', 'collaborator'].includes(
-                                  projectPermission,
-                                )
-                              "
+                              v-if="editMode"
                               @click="openColormapEditor(group.name, undefined)"
                             >
                               <div
@@ -1382,10 +1383,9 @@ onMounted(resetCurrentStyle);
                                 <template #append>
                                   <v-icon
                                     v-if="
-                                      item.project &&
-                                      ['owner', 'collaborator'].includes(
-                                        projectPermission,
-                                      )
+                                      item.project ==
+                                        projectStore.currentProject?.id &&
+                                      editMode
                                     "
                                     icon="mdi-pencil"
                                     class="ml-2"
@@ -1395,10 +1395,9 @@ onMounted(resetCurrentStyle);
                                   />
                                   <v-icon
                                     v-if="
-                                      item.project &&
-                                      ['owner', 'collaborator'].includes(
-                                        projectPermission,
-                                      )
+                                      item.project ==
+                                        projectStore.currentProject?.id &&
+                                      editMode
                                     "
                                     icon="mdi-trash-can"
                                     class="ml-2"
@@ -1439,11 +1438,7 @@ onMounted(resetCurrentStyle);
                             </template>
                             <template #prepend-item>
                               <v-list-item
-                                v-if="
-                                  ['owner', 'collaborator'].includes(
-                                    projectPermission,
-                                  )
-                                "
+                                v-if="editMode"
                                 @click="
                                   openColormapEditor(group.name, undefined)
                                 "
@@ -2069,7 +2064,7 @@ onMounted(resetCurrentStyle);
         </v-window>
       </v-card-text>
 
-      <v-card-actions class="my-1" style="float: right">
+      <v-card-actions v-if="editMode" class="my-1" style="float: right">
         <v-btn
           v-tooltip="'Warning: unsaved changes will be discarded'"
           class="secondary-button"

--- a/web/src/store/project.ts
+++ b/web/src/store/project.ts
@@ -49,7 +49,7 @@ export const useProjectStore = defineStore("project", () => {
   const permissions = computed(() => {
     const ret = Object.fromEntries(
       availableProjects.value.map((p) => {
-        let perm = "follower";
+        let perm = "";
         if (
           p.owner?.id === appStore.currentUser?.id ||
           appStore.currentUser?.is_superuser
@@ -60,6 +60,11 @@ export const useProjectStore = defineStore("project", () => {
           p.collaborators.map((u) => u.id).includes(appStore.currentUser.id)
         ) {
           perm = "collaborator";
+        } else if (
+          appStore.currentUser &&
+          p.followers.map((u) => u.id).includes(appStore.currentUser.id)
+        ) {
+          perm = "follower";
         }
         return [p.id, perm];
       }),

--- a/web/src/store/project.ts
+++ b/web/src/store/project.ts
@@ -9,7 +9,7 @@ import {
 } from "@/api/rest";
 import type { Dataset, Project, ViewState } from "@/types";
 import { defineStore } from "pinia";
-import { ref, watch } from "vue";
+import { ref, computed, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import {
@@ -45,6 +45,27 @@ export const useProjectStore = defineStore("project", () => {
   const availableViewStates = ref<ViewState[]>([]);
   const currentViewState = ref<ViewState>();
   const currentViewStateLoaded = ref<boolean>(false);
+
+  const permissions = computed(() => {
+    const ret = Object.fromEntries(
+      availableProjects.value.map((p) => {
+        let perm = "follower";
+        if (
+          p.owner?.id === appStore.currentUser?.id ||
+          appStore.currentUser?.is_superuser
+        ) {
+          perm = "owner";
+        } else if (
+          appStore.currentUser &&
+          p.collaborators.map((u) => u.id).includes(appStore.currentUser.id)
+        ) {
+          perm = "collaborator";
+        }
+        return [p.id, perm];
+      }),
+    );
+    return ret;
+  });
 
   async function fetchProjectDatasets() {
     if (!currentProject.value) {
@@ -314,6 +335,7 @@ export const useProjectStore = defineStore("project", () => {
     availableViewStates,
     currentViewState,
     currentViewStateLoaded,
+    permissions,
     fetchProjectDatasets,
     fetchAvailableDatasetTags,
     fetchProjectViewStates,


### PR DESCRIPTION
This PR fixes the project permission logic for followers. On the server-side, this means adding several checks to API endpoints that allow creation of objects associated with a project (analytics runs, layer styles, colormaps, and view states). On the client side, this means consolidating the logic for project permissions to a new computed variable `permissions` in the project store. Several components needed updates to conditionally render controls according to those permissions.