### PR TITLE
Remove non-functional icons

### DIFF
--- a/web/src/components/sidebars/AnalyticsPanel.vue
+++ b/web/src/components/sidebars/AnalyticsPanel.vue
@@ -555,7 +555,6 @@ watch(
               icon="mdi-information-outline"
               size="small"
             ></v-icon>
-            <v-icon icon="mdi-earth" size="small" class="ml-2"></v-icon>
           </template>
         </v-list-item>
       </v-list>

--- a/web/src/components/sidebars/ChartsPanel.vue
+++ b/web/src/components/sidebars/ChartsPanel.vue
@@ -229,7 +229,6 @@ const downloadReady = computed(() => {
               icon="mdi-information-outline"
               size="small"
             ></v-icon>
-            <v-icon icon="mdi-poll" size="small" class="ml-2"></v-icon>
             <DetailView :details="{ ...chart, type: 'chart' }" />
           </template>
         </v-list-item>

--- a/web/src/components/sidebars/NetworksPanel.vue
+++ b/web/src/components/sidebars/NetworksPanel.vue
@@ -287,11 +287,6 @@ watch(
           >
             {{ network.name }}
             <template #append>
-              <v-icon
-                icon="mdi-transit-connection-variant"
-                size="small"
-                class="ml-2"
-              ></v-icon>
               <DetailView :details="{ ...network, type: 'network' }" />
             </template>
           </v-list-item>


### PR DESCRIPTION
The Charts, Networks, and Analytics panels have some extra icons that don't do anything. They were intended to communicate the type of the objects in each list, but since they are shown among icons that have other functions (description tooltip and details dialog), it could be confusing that these icons don't do anything. Besides, the items in these lists all have the same type as indicated by the panel they're in.

This PR removes those unnecessary icons.